### PR TITLE
Added Interfaces for webhooks and JSON Schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 	"devDependencies": {
 		"@types/express": "^4.17.12",
 		"@types/express-session": "^1.17.3",
+		"@types/json-schema": "^7.0.7",
 		"@types/jsonwebtoken": "^8.5.1",
 		"@types/node": "^15.12.1",
 		"concurrently": "^6.2.0",
@@ -40,6 +41,7 @@
 		"typescript": "^4.3.2"
 	},
 	"dependencies": {
+		"ajv": "^8.6.0",
 		"axios": "^0.21.1",
 		"body-parser": "^1.19.0",
 		"chalk": "^4.1.1",

--- a/src/Types/hubspot-payload-schema.json
+++ b/src/Types/hubspot-payload-schema.json
@@ -1,0 +1,26 @@
+{
+    "title": "HubSpot Webhook Payload",
+    "description": "The payload of a HubSpot webhook",
+    "type": "array",
+    "items":{
+        "type": "object",
+        "properties": {
+            "eventId": {"type": "number"},
+            "subscriptionId": {"type": "number"},
+            "portalId": {"type": "number"},
+            "appId": {"type": "number"},
+            "occurredAt": {"type": "number"},
+            "subscriptionType": {"type": "string"},
+            "attemptNumber": {"type": "number"},
+            "objectId": {"type": "number"},
+            "propertyName": {"type": "string"},
+            "propertyValue": {"type": "string"},
+            "changeFlag": {"type": "string"},
+            "changeSource": {"type": "string"}
+            
+            
+        },
+        "required": ["eventId", "subscriptionId", "portalId", "appId", "occurredAt", "subscriptionType", "attemptNumber", "objectId", "changeSource"],
+        "additionalProperties": false
+    }
+}

--- a/src/Types/saasquatch-payload-schema.json
+++ b/src/Types/saasquatch-payload-schema.json
@@ -1,0 +1,15 @@
+{
+    "title": "SaaSquatch Webhook Payload",
+    "description": "The payload of a SaaSquatch webhook",
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "type": {"type": "string"},
+        "tenantAlias": {"type": "string"},
+        "live": {"type": "boolean"},
+        "created": {"type": "number"},
+        "data": {"type": "object"}
+    },
+    "required": ["id", "type", "tenantAlias", "live", "created", "data"],
+    "additionalProperties": false
+}

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -1,0 +1,66 @@
+
+
+/**
+ * HubSpot interfaces for webhooks
+ */
+
+export enum SubscriptionType {
+    ContactCreation = 'contact.creation',
+    ContactDeletion = 'contact.deletion', 
+    ContactPrivacyDelection = 'contact.privacyDeletion', 
+    ContactPropertyChange = 'contact.propertyChange', 
+    CompanyCreation = 'company.creation',
+    CompanyDeletion = 'company.deletion',
+    CompanyPropertyChange = 'company.propertyChange',
+    DealCreation = 'deal.creation', 
+    DealDeletion = 'deal.deletion', 
+    DealPropertyChange = 'deal.propertyChange'
+ }
+
+export interface HubspotPayload{
+    eventId: number;
+    subscriptionId: number;
+    portalId: number;
+    appId: number;
+    occurredAt: number;
+    subscriptionType: SubscriptionType;
+    attemptNumber: number;
+    objectId: number;
+    propertyName?: string;
+    propertyValue?: string;
+    changeFlag?: string;
+    changeSource: string;
+}
+
+
+/**
+ * SaaSquatch interfaces for webhooks
+ */
+
+export enum EventType {
+  UserCreated = 'user.created',
+  UserRewardBalanceChanged = 'user.reward.balance.changed',
+  CouponCreated = 'coupon.created', 	
+  RewardCreated = 'reward.created', 
+  EmailReferredRewardEarned = 'email.referred.reward.earned', 	
+  EmailReferralStarted = 'email.referral.started', 
+  EmailReferralPaid = 'email.referral.paid',
+  EmailReferralRewardLimitReached = 'email.referral.rewardLimitReached',
+  ReferralAutomoderationComplete = 'referral.automoderation.complete',
+  ReferralStarted = 'referral.started',
+  ReferralConverted = 'referral.converted',
+  ReferralEnded = 'referral.ended',
+  ThemePublishFinished = 'theme.publish.finished',
+  ExportCreated = 'export.created',
+  ExportCompleted = 'export.completed',
+  Test = 'test'
+}
+
+export interface SaasquatchPayload{
+    id: string,
+    type: EventType,
+    tenantAlias: string,
+    live: boolean,
+    created: number,
+    data: object
+}

--- a/src/integration/hubspot-updates.ts
+++ b/src/integration/hubspot-updates.ts
@@ -1,0 +1,55 @@
+import { HubspotPayload } from "../Types/types";
+
+/**
+ * Sample boilerplate functions
+ */
+
+/**
+ * Received webhook of subscription type 'contact.created'
+ * @param hubspotPayload Payload of Hubspot webhook
+ */
+export function NewContact(hubspotPayload: HubspotPayload){
+    console.log('received HubSpot contact.creation');
+    /**
+     * TODO:
+     * Steps
+     * 1. Check if contact exists as user in SaaSquatch (match by email)
+     * 2. If it does not exist, create new user in SaaSquatch
+     * 3. If it does exist, get referral link and other relevant data
+     *  a) post referral link back to hubspot to add to contact
+     * 4. Done?
+     */
+}
+
+/**
+ * Received webhook of subscription type 'contact.deletion'
+ * @param hubspotPayload Payload of Hubspot webhook
+ */
+ export function DeletedContact(hubspotPayload: HubspotPayload){
+    console.log('received HubSpot contact.deletion');
+    /**
+     * TODO:
+     * Steps
+     * 1. Check if contact exists as user in SaaSquatch (match by email)
+     * 2. If it does not exist, do nothing
+     * 3. If it does exist, post to hubspot to delete user?
+     * 4. Done?
+     */
+}
+
+
+/**
+ * Received webhook of subscription type 'contact.propertyChange'
+ * @param hubspotPayload Payload of Hubspot webhook
+ */
+ export function ChangedContact(hubspotPayload: HubspotPayload){
+    console.log('received HubSpot contact.propertyChange');
+    /**
+     * TODO:
+     * Steps
+     * 1. Check if contact exists as user in SaaSquatch (match by email)
+     * 2. If it does not exist, do nothing? or create contact?
+     * 3. If it does exist, update properties
+     * 4. Done?
+     */
+}

--- a/src/integration/saasquatch-updates.ts
+++ b/src/integration/saasquatch-updates.ts
@@ -1,0 +1,35 @@
+import { SaasquatchPayload } from "../Types/types";
+
+
+/**
+ * Sample boilerplate functions
+ */
+
+
+
+/**
+ * Received webhook of event type 'user.created'
+ * @param saasquatchPayload Payload of SaaSquatch webhook
+ */
+export function NewUser(saasquatchPayload: SaasquatchPayload){
+    console.log('Received SaaSquatch user.created. This is not yet implemented.');
+    
+    /**
+     * TODO:
+     * Steps
+     * 1. Check if user exists as contact in HubSpot (match by email)
+     * 2. If it does not exist, create new contact in HubSpot
+     * 3. If it does exist, send referral link to HubSpot for that contact.
+     * 4. Done?
+     */
+}
+
+
+/**
+ * Received webhook of event type 'test'. No processing required as this is a test webhook.
+ * 
+ * @param saasquatchPayload Payload of SaaSquatch webhook
+ */
+ export function Test(saasquatchPayload: SaasquatchPayload){
+    console.log('Received SaaSquatch test webhook.');  
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,7 @@
 		// "types": [],                                 /* Type declaration files to be included in compilation. */
 		// "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
 		"esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+		"resolveJsonModule": true,
 		// "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
 		// "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
 		/* Source Map Options */


### PR DESCRIPTION
This PR contains changes to handle webhooks.
- Added Interfaces for both HubSpot and SaaSquatch webhooks. 
- Added JSON Schemas to validate JSON data of request bodies. (Note: for SaaSquatch this does not validate format of data object as this varies greatly between webhook types)
- Added basic flow for determining HubSpot subscriptionType and SaaSquatch eventType.
- Boilerplate functions for some of the HubSpot and SaaSquatch webhooks (eg. HubSpot contact.creation goes to `HubspotUpdates.NewContact()`)

All feedback is appreciated, I feel I made quite a few assumptions on how we wanted to do this. In particular, I wasn't sure how to structure this in regards to different files/folders.

Sprint Goal: When a create user in Hubspot/SaaSquatch then they are created in the opposite application.

Trello Ticket: https://trello.com/c/vrBCKWas