### PR TITLE
added functionality to push hubspot contacts to saasquatch on creation

### DIFF
--- a/src/integration/SaasquatchApiModel.ts
+++ b/src/integration/SaasquatchApiModel.ts
@@ -51,6 +51,22 @@ export class SaasquatchApiModel {
         }
         }
 
+        public async createParticipant(email:string, createParticipantBody:object){
+            try{
+                //URL should be built using express URL class
+                const createParticipantURL = 'https://staging.referralsaasquatch.com/api/v1/' +this.TENANTALIAS+ '/open/account/' + email + '/user/' + email;
+                const response = await axios.post(createParticipantURL, createParticipantBody,{
+                    headers: {
+                      'Authorization':'token '+this.SAPIKEY
+                  }
+                  });
+                return response;
+            } catch (e) {
+                console.error("Was not able to create contact");
+                console.log(e);
+            }
+        }
+
 
    
 

--- a/src/integration/hubspotUpdatesController.ts
+++ b/src/integration/hubspotUpdatesController.ts
@@ -13,6 +13,8 @@ export class hubspotUpdatesController{
         this.hubApiModel = new HubspotApiModel(hApiKey);
     }
 
+    
+   
     /**
      * Received webhook of subscription type 'contact.created'
      * @param hubspotPayload Payload of Hubspot webhook
@@ -26,18 +28,29 @@ export class hubspotUpdatesController{
         // Hubspot does not include email in contact.created
         // Get new contact's email
         let params ='';
-        this.hubApiModel.getContact(contactObjectId, 'email')
+        this.hubApiModel.getContact(contactObjectId)
         .then(data =>{
             console.log("response");
             console.log(data);
+            const participant = data;
             params = `email:${encodeURIComponent(data.properties.email)}`;
+            console.log("PARAMS");
             console.log(params);
             // 1. Check if contact exists as user in SaaSquatch (match by email)
             this.saasApiModel.getUsers(params)
             .then( data =>{
-                // 2. TODO: If it does not exist, create new user in SaaSquatch
+                //If it does not exist, create new user in SaaSquatch
                 if(data.count == 0){
                     console.log("User does not exist in SaaSquatch");
+                    const createParticipantBody = {
+                            "email": participant.properties.email,
+                            "firstName": participant.properties.firstname,
+                            "lastName": participant.properties.lastname,
+                            "id": participant.properties.email,
+						    "accountId": participant.properties.email,
+            
+                    };
+                    this.saasApiModel.createParticipant(participant.properties.email, createParticipantBody);
                 }
                 // 3. TODO: If it does exist, get share link and other relevant data
                 else{


### PR DESCRIPTION
This adds functionality to push participants to saasquatch when we receive a webhook of event type 'user.created' from hubspot. It requires both the hubspot and saasquatch webhooks to be setup manually

changes to hubspotUpdatesController.ts
- added to NewContact() so that when a user doesn't exist in saasquatch a user is created

changes to SaasquatchApiModel.ts
- added a createParticipant() that posts a new participant to saasquatch given an email, firstName, lastName, id, and account ID