### PR TITLE
Added ts-jest and test for webhook verification and JSON schema valid…

### DIFF
--- a/features/Hubspot-to-SaaSquatch/Generate Share Links For Hubspot Contacts.feature
+++ b/features/Hubspot-to-SaaSquatch/Generate Share Links For Hubspot Contacts.feature
@@ -6,10 +6,14 @@ Feature: Generate Share Links For Hubspot Contacts
     Background:
         Given the integration is active
 
-    Scenario: Contacts get share links
-        When a Contact is created in Hubspot
+    
+    Scenario: New HubSpot Contacts that already exist in SaaSquatch get share links
+        When A Contact is created in Hubspot
+        And they exist in SaaSquatch
+        Then their share link shows up back in Hubspot
+    
+    Scenario: New HubSpot Contacts that do not yet exist in SaaSquatch get share links
+        When A Contact is created in Hubspot
         But they don't exist in SaaSquatch
         Then they are created in SaaSquatch
-        And generated a share link
-        And that link shows up in Hubspot
-    
+        And their generated share link shows up back in Hubspot

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    moduleFileExtensions: ["js", "ts", "json"],
+    globals: {
+        'ts-jest': {
+          tsConfig: "<rootDir>/tsconfig.json",
+          isolatedModules: true,
+        }
+      },
+    roots: [
+        '<rootDir>/src'
+      ],
+      testMatch: [
+        '<rootDir>/src/test/**/*.steps.ts'
+      ],    
+    setupFiles: ["<rootDir>/src/jest/setEnvVars.ts"],
+    preset: "ts-jest"
+}; 

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,0 @@
-{
-    "testMatch": [
-        "**/*.steps.js"
-    ]
-}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"watch": "concurrently \"npm run server\" \"npm run frontend\"",
 		"start": "node ./build",
 		"heroku-postbuild": "bash ./production-build.sh",
-		"test": "tsc **/test/*.ts && jest && rm **/test/*.js",
+		"test": "jest",
 		"build-tests": "tsc **/test/*.ts",
 		"run-tests": "jest",
 		"clean-tests": "rm **/test/*.js"
@@ -56,7 +56,6 @@
 		"js-base64": "^3.6.1",
 		"jsonwebtoken": "^8.5.1",
 		"jwks-rsa": "^2.0.3",
-		"query-string": "^7.0.0",
-		"querystring": "^0.2.1"
+		"query-string": "^7.0.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -35,16 +35,18 @@
 	"devDependencies": {
 		"@types/express": "^4.17.12",
 		"@types/express-session": "^1.17.3",
+		"@types/jest": "^26.0.23",
 		"@types/json-schema": "^7.0.7",
 		"@types/jsonwebtoken": "^8.5.1",
 		"@types/node": "^15.12.1",
 		"chai": "^4.3.4",
 		"concurrently": "^6.2.0",
-		"jest": "26.6.0",
+		"jest": "^27.0.5",
 		"jest-cucumber": "^3.0.1",
 		"nodemon": "^2.0.7",
+		"ts-jest": "^27.0.3",
 		"ts-node": "^10.0.0",
-		"typescript": "^4.3.2"
+		"typescript": "^4.3.4"
 	},
 	"dependencies": {
 		"ajv": "^8.6.0",

--- a/src/integration/HubspotApiModel.ts
+++ b/src/integration/HubspotApiModel.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import querystring from 'querystring';
 
 export class HubspotApiModel {
 

--- a/src/integration/SaasquatchApiModel.ts
+++ b/src/integration/SaasquatchApiModel.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import querystring from 'querystring';
 
 export class SaasquatchApiModel {
 

--- a/src/jest/setEnvVars.ts
+++ b/src/jest/setEnvVars.ts
@@ -1,0 +1,4 @@
+/**
+ * Fake env variables for testing purposes
+ */
+ process.env.HUBSPOT_CLIENT_SECRET = '12345-ABCDE-12345-ABCDE';

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -2,7 +2,6 @@ import { Router } from 'express';
 require('dotenv').config();
 import axios from 'axios';
 const querystring = require('query-string');
-//import querystring from 'querystring';
 
 const router = Router();
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -3,7 +3,6 @@ import { Router } from 'express';
 import * as jwt from "jsonwebtoken";
 import jwksRsa = require("jwks-rsa");
 import { Base64 } from "js-base64";
-import crypto from "crypto";
 import { SubscriptionType, HubspotPayload, SaasquatchPayload, EventType } from '../Types/types';
 import saasquatchSchema from '../Types/saasquatch-payload-schema.json';
 import hubspotSchema from '../Types/hubspot-payload-schema.json';
@@ -48,7 +47,7 @@ const validateSaasquatchSchema = ajv.getSchema("saasquatch");
 const hubUpdatesController = new hubspotUpdatesController(process.env.HAPIKEY, process.env.SAPIKEY, process.env.STENANTALIAS);
 const saasUpdatesController = new saasquatchUpdatesController(process.env.HAPIKEY, process.env.SAPIKEY, process.env.STENANTALIAS);
 
-
+const crypto = require("crypto");
 
 /**
  * Endpoint for webhooks from SaaSquatch

--- a/src/test/generate-share-links-for-hubspot-contacts.steps.ts
+++ b/src/test/generate-share-links-for-hubspot-contacts.steps.ts
@@ -1,0 +1,118 @@
+import { loadFeature, defineFeature } from 'jest-cucumber';
+import { HubspotPayload, SubscriptionType } from '../Types/types';
+import { validateHubSpotWebhook } from '../routes/webhooks';
+import hubspotSchema from '../Types/hubspot-payload-schema.json';
+import Ajv from "ajv";
+
+const ShareLinkForHubspotContacts = loadFeature('features/Hubspot-to-SaaSquatch/Generate Share Links For Hubspot Contacts.feature');
+
+
+defineFeature(ShareLinkForHubspotContacts, test => {
+    const validWebhookRequestBody: any = [
+        {
+          "objectId": 1246965,
+          "propertyName": "lifecyclestage",
+          "propertyValue": "subscriber",
+          "changeSource": "ACADEMY",
+          "eventId": 3816279340,
+          "subscriptionId": 25,
+          "portalId": 33,
+          "appId": 1160452,
+          "occurredAt": 1462216307945,
+          "subscriptionType":"contact.propertyChange",
+          "attemptNumber": 0
+        },
+        {
+          "objectId": 1246978,
+          "changeSource": "IMPORT",
+          "eventId": 3816279480,
+          "subscriptionId": 22,
+          "portalId": 33,
+          "appId": 1160452,
+          "occurredAt": 1462216307945,
+          "subscriptionType": "contact.creation",
+          "attemptNumber": 0
+        }
+    ];
+
+    const testFakeClientSecret = process.env.HUBSPOT_CLIENT_SECRET;
+    const webhookSigVersion = 'v1';
+    const crypto = require("crypto");
+    const webhookSig = crypto.createHash('sha256').update(testFakeClientSecret + validWebhookRequestBody).digest('hex');
+
+    const invalidWebhookRequestBody: any = [
+        {
+          "objectId": 1246978,
+          "changeSource": "IMPORT",
+          "eventId": 3816279480,
+          "subscriptionId": 22,
+          "portalId": 33,
+          "appId": 1160452,
+          "occurredAt": "contact.creation",
+          "subscriptionType": 0,
+          "attemptNumber": null
+        }
+    ];
+
+    const invalidWebhookSig = crypto.createHash('sha256').update(JSON.stringify(validWebhookRequestBody)).digest('hex');
+
+    // JSON schema validator
+    const ajv: any = new Ajv();
+    const hubSchema: Object = hubspotSchema;
+    ajv.addSchema(hubSchema, "hubspot");
+
+    const validateHubspotSchema = ajv.getSchema("hubspot");
+
+
+
+    test('New HubSpot Contacts that do not yet exist in SaaSquatch get share links', ({given, when, but, then, and}) => {
+        given('The integration is active', () => {
+            // This is assumed for now, as system config in db is not yet set up
+        });
+        when('A Contact is created in Hubspot', () => {
+            // validate well-formatted webhook from HubSpot
+            expect(validateHubSpotWebhook(webhookSigVersion, webhookSig, validWebhookRequestBody)).toBe(true);
+            expect(validateHubspotSchema(validWebhookRequestBody)).toBe(true);
+            expect(validWebhookRequestBody[1].subscriptionType).toBe(SubscriptionType.ContactCreation);
+
+            // confirm invalid webhook from not HubSpot (fake webhook)
+            expect(validateHubSpotWebhook(webhookSigVersion, invalidWebhookSig, validWebhookRequestBody)).toBe(false);
+            // confirm JSON Schema validation fails on malformed webhook JSON 
+            expect(validateHubspotSchema(invalidWebhookRequestBody)).toBe(false);            
+
+        });
+        but('they don\'t exist in SaaSquatch', () => {
+            //api call to get saasquatch users
+            //match on email
+        });
+        then('they are created in SaaSquatch', () => {
+            //api call to create saasquatch user with data from hubspot
+        });
+        and('their generated share link shows up back in Hubspot', () => {
+            //api call at add share link to hubspot user
+        });
+    });
+
+   
+    test('New HubSpot Contacts that already exist in SaaSquatch get share links', ({given, when, and, then}) => {
+        given('The integration is active', () => {
+            // This is assumed for now, as system config in db is not yet set up
+        });
+        when('A Contact is created in Hubspot', () => {
+            // validate webhook from HubSpot
+            
+        });
+        and('they exist in SaaSquatch', () => {
+            //api call to get saasquatch users
+            //match on email
+        });
+        then('their share link shows up back in Hubspot', () => {
+            //api call at add share link to hubspot user
+        });
+        
+    });
+
+
+
+
+});


### PR DESCRIPTION
This PR adds ts-jest to manage the jest transform required for typescript files.
Tests can be run using `yarn test` or `npm test`

Additionally, a basic test to confirm webhook verification is working with HubSpot requests was added with a template for the rest of the feature.

Please pull this branch and confirm that you can run the tests using one of the commands above before approving :)