### PR TITLE
Fix frontend auth token cookie for Chrome

### DIFF
--- a/frontend/src/components/ConfigurationP1.tsx
+++ b/frontend/src/components/ConfigurationP1.tsx
@@ -122,7 +122,7 @@ export function Controller(){
   const [oneway, setOneway] = useState(true);
 
   const postConfigData = async () => {
-      return await fetch(API_CONFIGURATION_URL + `?token=${document.cookie}`, {
+      return await fetch(API_CONFIGURATION_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ 
@@ -135,9 +135,7 @@ export function Controller(){
   // Gets config data on page load
   useEffect(() => {
     const getConfigData = () => {
-      axios.get(API_CONFIGURATION_URL,
-        { params: {token: document.cookie} }
-      )
+      axios.get(API_CONFIGURATION_URL)
       .then((response) => {
         // A blank config object is returned if the user doesn't exist yet in the database
         if (
@@ -208,7 +206,7 @@ export function Controller(){
   // On submit we make a request to the backend to store the config data and redirect to second config screen
   const handleSubmit = () => {
     const putConfigData = async () => {
-        return await fetch(API_CONFIGURATION_URL + `?token=${document.cookie}`, {
+        return await fetch(API_CONFIGURATION_URL, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ 

--- a/frontend/src/components/ConfigurationP2.tsx
+++ b/frontend/src/components/ConfigurationP2.tsx
@@ -146,9 +146,7 @@ export function Controller(){
   // Gets config data on page load
   useEffect(() => {
     const getConfigData = () => {
-      axios.get(API_CONFIGURATION_URL,
-        { params: {token: document.cookie} }
-      )
+      axios.get(API_CONFIGURATION_URL)
       .then((response) => {
         setConfig(config => ({...config, pushIntoParticipants: response.data.PushContactsAsParticipants, pullIntoParticipants: response.data.PullContactsIntoParticipants}));
         // Disable import toggle if previously imported
@@ -216,7 +214,7 @@ export function Controller(){
   // On submit we make a request to the backend to store the config data and redirect to integration success screen if config selected
   const handleSubmit = () => {
     const putConfigData = async () => {
-      return await fetch(API_CONFIGURATION_URL + `?token=${document.cookie}`, {
+      return await fetch(API_CONFIGURATION_URL, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ 

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -72,9 +72,7 @@ export function OAuthFunction(){
     setError(false);
 
     // Check Server for Hubspot Authorization
-    await axios.get(HUBSPOT_AUTHORIZATION,
-      { params: {token: document.cookie} }
-    )
+    await axios.get(HUBSPOT_AUTHORIZATION)
     .then(response => {
       if (response.data === "Unauthorized"){
         // Get Hubspot OAuth URL from server
@@ -86,9 +84,7 @@ export function OAuthFunction(){
           var timer = setInterval(function() { 
             if(popup && popup.closed) {
               // Check Server for Hubspot Authorization
-              axios.get(HUBSPOT_AUTHORIZATION,
-                { params: {token: document.cookie} }
-              )
+              axios.get(HUBSPOT_AUTHORIZATION)
               .then(response => {
                 // Send user to configuration page if authorized
                 if (response.data === "Authorized"){

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"axios": "^0.21.1",
 		"body-parser": "^1.19.0",
 		"chalk": "^4.1.1",
+		"cookie-parser": "^1.4.5",
 		"dotenv": "^10.0.0",
 		"express": "^4.17.1",
 		"firebase": "^8.6.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,9 @@ const bodyParser = require('body-parser');
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
+const cookieParser = require("cookie-parser");
+app.use(cookieParser());
+
 // dynamic routes
 app.use(routes);
 app.use(oauthroutes);

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -17,8 +17,8 @@ const configurationController = new ConfigurationController();
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.token) {
-		decoded = authenticateToken(req.cookies.token as string)
+	if(req.cookies.frontendToken) {
+		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if (decoded != undefined) {
 		const configuration = await configurationController.getConfiguration()
@@ -32,8 +32,8 @@ router.get(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.post(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.token) {
-		decoded = authenticateToken(req.cookies.token as string)
+	if(req.cookies.frontendToken) {
+		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {
 		const configuration: Configuration = req.body as Configuration
@@ -52,8 +52,8 @@ router.post(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.put(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.token) {
-		decoded = authenticateToken(req.cookies.token as string)
+	if(req.cookies.frontendToken) {
+		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {
 		const configuration: Configuration = req.body as Configuration

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -17,8 +17,8 @@ const configurationController = new ConfigurationController();
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.query.token) {
-		decoded = authenticateToken(req.query.token as string)
+	if(req.cookies.token) {
+		decoded = authenticateToken(req.cookies.token as string)
 	}
 	if (decoded != undefined) {
 		const configuration = await configurationController.getConfiguration()
@@ -32,8 +32,8 @@ router.get(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.post(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.query.token) {
-		decoded = authenticateToken(req.query.token as string)
+	if(req.cookies.token) {
+		decoded = authenticateToken(req.cookies.token as string)
 	}
 	if(validate(req.body) && decoded != undefined) {
 		const configuration: Configuration = req.body as Configuration
@@ -52,8 +52,8 @@ router.post(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.put(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.query.token) {
-		decoded = authenticateToken(req.query.token as string)
+	if(req.cookies.token) {
+		decoded = authenticateToken(req.cookies.token as string)
 	}
 	if(validate(req.body) && decoded != undefined) {
 		const configuration: Configuration = req.body as Configuration

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -103,8 +103,8 @@ export const getSaasquatchToken = async () =>  {
 // 1. Check whether user has previously authenticated with Hubspot and received a token
 router.get('/hubspot_authorization', async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.token) {
-		decoded = authenticateToken(req.cookies.token as string)
+	if(req.cookies.frontendToken) {
+		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
     if(decoded != undefined) {
         try {
@@ -188,8 +188,8 @@ router.get('/hubspot', async (req, res) => {
 	const hubspotID = req.query.hubspotID;
     if(hubspotID) {
         try {
-			const token = generateAccessToken(hubspotID as string);
-			res.status(200).send(`<script>document.cookie="token=${token}; SameSite=None; Secure"; window.close();</script>`);
+			const frontendToken = generateAccessToken(hubspotID as string);
+			res.status(200).send(`<script>document.cookie="frontendToken=${frontendToken}; SameSite=None; Secure"; window.close();</script>`);
         }
         catch(e){
             console.error(e);

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -103,8 +103,8 @@ export const getSaasquatchToken = async () =>  {
 // 1. Check whether user has previously authenticated with Hubspot and received a token
 router.get('/hubspot_authorization', async (req, res) => {
 	let decoded = undefined
-	if(req.query.token) {
-		decoded = authenticateToken(req.query.token as string)
+	if(req.cookies.token) {
+		decoded = authenticateToken(req.cookies.token as string)
 	}
     if(decoded != undefined) {
         try {
@@ -189,7 +189,7 @@ router.get('/hubspot', async (req, res) => {
     if(hubspotID) {
         try {
 			const token = generateAccessToken(hubspotID as string);
-			res.status(200).send(`<script>document.cookie="${token}"; window.close();</script>`);
+			res.status(200).send(`<script>document.cookie="token=${token}; SameSite=None; Secure"; window.close();</script>`);
         }
         catch(e){
             console.error(e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,6 +4113,14 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-parser@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.5.tgz#3e572d4b7c0c80f9c61daf604e4336831b5d1d49"
+  integrity sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==
+  dependencies:
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"


### PR DESCRIPTION
Using the frontend auth token in a cookie prevented logging in from the SaaSquatch iFrame in Chrome. This PR fixes that functionality by allowing the cookie to have SameSite=None I also added the cookie parser which made it easier to access in the backend.