### PR TITLE
Add eslint linter and husky to force no lint errors on commit

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+features
+build
+src/Types/types.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,25 +1,25 @@
 module.exports = {
-    parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+    parser: '@typescript-eslint/parser', // Specifies the ESLint parser
     parserOptions: {
-      ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features 
-      sourceType: "module", // Allows for the use of imports
-      ecmaFeatures: {
-        jsx: true // Allows for the parsing of JSX
-      }
+        ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
+        sourceType: 'module', // Allows for the use of imports
+        ecmaFeatures: {
+            jsx: true, // Allows for the parsing of JSX
+        },
     },
-    settings: {
-      react: {
-        version: "detect" // Tells eslint-plugin-react to automatically detect the version of React to use
-      }
+    env: {
+        browser: true,
+        node: true,
     },
+    plugins: ['@typescript-eslint'],
     extends: [
-      "plugin:@typescript-eslint/recommended", // Uses the recommended rules from @typescript-eslint/eslint-plugin
-      //"prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-      //"plugin:prettier/recommended" // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors.
+        'eslint:recommended',
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
     ],
     rules: {
-      "no-console": [1, { "allow": ["warn", "error"] }],
-      "@typescript-eslint/no-var-requires": 0,
-      "no-unused-vars": 1
+        'no-console': [1, { allow: ['warn', 'error'] }],
+        '@typescript-eslint/no-var-requires': 0,
+        'no-unused-vars': 1,
     },
-  };
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+    parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+    parserOptions: {
+      ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features 
+      sourceType: "module", // Allows for the use of imports
+      ecmaFeatures: {
+        jsx: true // Allows for the parsing of JSX
+      }
+    },
+    settings: {
+      react: {
+        version: "detect" // Tells eslint-plugin-react to automatically detect the version of React to use
+      }
+    },
+    extends: [
+      "plugin:@typescript-eslint/recommended", // Uses the recommended rules from @typescript-eslint/eslint-plugin
+      //"prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+      //"plugin:prettier/recommended" // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors.
+    ],
+    rules: {
+      "no-console": [1, { "allow": ["warn", "error"] }],
+      "@typescript-eslint/no-var-requires": 0,
+      "no-unused-vars": 1
+    },
+  };

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '*.ts': ['eslint --maxwarnings=0', 'prettier --write'],
+};

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    semi: true,
+    trailingComma: "all",
+    singleQuote: true,
+    printWidth: 120,
+    tabWidth: 4
+  };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,21 @@
 		"test": "yarn run build-tests && yarn run run-tests && yarn run clean-tests",
 		"build-tests": "tsc --resolveJsonModule --esModuleInterop **/test/*.ts",
 		"run-tests": "jest",
-		"clean-tests": "rm ./src/**/*.js ./src/*.js"
+		"clean-tests": "rm ./src/**/*.js ./src/*.js",
+		"lint": "eslint 'src/**/*.{js,ts,tsx}' --fix",
+		"prettify": "prettier src/**/*.{js,ts,tsx} --write"
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	},
+	"lint-staged": {
+		"*.{js,ts,tsx}": [
+			"prettier --write",
+			"git add",
+			"yarn run lint"
+		]
 	},
 	"repository": {
 		"type": "git",
@@ -42,10 +56,19 @@
 		"@types/node": "^15.12.1",
 		"@types/selenium-webdriver": "^4.0.14",
 		"@types/wait-on": "^5.3.0",
+		"@typescript-eslint/eslint-plugin": "^4.28.4",
+		"@typescript-eslint/parser": "^4.28.4",
 		"chai": "^4.3.4",
 		"chromedriver": "^91.0.1",
 		"concurrently": "^6.2.0",
+		"eslint": "^7.31.0",
+		"eslint-config-prettier": "^8.3.0",
+		"eslint-plugin-prettier": "^3.4.0",
+		"eslint-plugin-react": "^7.24.0",
+		"husky": "^7.0.1",
+		"lint-staged": "^11.0.1",
 		"nodemon": "^2.0.7",
+		"prettier": "^2.3.2",
 		"ts-node": "^10.0.0",
 		"typescript": "^4.3.4"
 	},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"run-tests": "jest",
 		"clean-tests": "rm ./src/**/*.js ./src/*.js",
 		"lint": "eslint 'src/**/*.{js,ts,tsx}' --fix",
-		"prettify": "prettier src/**/*.{js,ts,tsx} --write"
+		"prettify": "prettier src/**/*.{js,ts,tsx} --write",
+		"prepare": "husky install"
 	},
 	"husky": {
 		"hooks": {
@@ -26,7 +27,6 @@
 	"lint-staged": {
 		"*.{js,ts,tsx}": [
 			"prettier --write",
-			"git add",
 			"yarn run lint"
 		]
 	},
@@ -65,7 +65,7 @@
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-prettier": "^3.4.0",
 		"eslint-plugin-react": "^7.24.0",
-		"husky": "^7.0.1",
+		"husky": "^7.0.0",
 		"lint-staged": "^11.0.1",
 		"nodemon": "^2.0.7",
 		"prettier": "^2.3.2",

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -67,15 +67,15 @@ export interface SaasquatchPayload {
  */
 
 export interface Configuration {
-    PushPartixipantsAsContacts: boolean, 
-    PullParticipantsIntoContacts: boolean,
-    DeleteContactwhenParticipantDeleted: boolean,
-    PushContactsAsParticipants: boolean,
-    PullContactsIntoParticipants: boolean, 
-    DeleteParticipantWhenContactDeleted: boolean,
-    hubspotID: string,
-    accessToken: string, 
-    refreshToken: string
+    PushPartixipantsAsContacts: boolean;
+    PullParticipantsIntoContacts: boolean;
+    DeleteContactwhenParticipantDeleted: boolean;
+    PushContactsAsParticipants: boolean;
+    PullContactsIntoParticipants: boolean;
+    DeleteParticipantWhenContactDeleted: boolean;
+    hubspotID: string;
+    accessToken: string;
+    refreshToken: string;
 }
 
 /**

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -1,4 +1,3 @@
-
 /**
  * HubSpot interfaces for webhooks
  */
@@ -13,10 +12,10 @@ export enum SubscriptionType {
     CompanyPropertyChange = 'company.propertyChange',
     DealCreation = 'deal.creation',
     DealDeletion = 'deal.deletion',
-    DealPropertyChange = 'deal.propertyChange'
+    DealPropertyChange = 'deal.propertyChange',
 }
 
-export interface HubspotPayload{
+export interface HubspotPayload {
     eventId: string;
     subscriptionId: number;
     portalId: number;
@@ -30,7 +29,6 @@ export interface HubspotPayload{
     changeFlag?: string;
     changeSource: string;
 }
-
 
 /**
  * SaaSquatch interfaces for webhooks
@@ -52,16 +50,16 @@ export enum EventType {
     ThemePublishFinished = 'theme.publish.finished',
     ExportCreated = 'export.created',
     ExportCompleted = 'export.completed',
-    Test = 'test'
+    Test = 'test',
 }
 
-export interface SaasquatchPayload{
-    id: string,
-    type: EventType,
-    tenantAlias: string,
-    live: boolean,
-    created: number,
-    data: object
+export interface SaasquatchPayload {
+    id: string;
+    type: EventType;
+    tenantAlias: string;
+    live: boolean;
+    created: number;
+    data: any;
 }
 
 /**
@@ -69,7 +67,6 @@ export interface SaasquatchPayload{
  */
 
 export interface Configuration {
-
     PushPartixipantsAsContacts: boolean, 
     PullParticipantsIntoContacts: boolean,
     DeleteContactwhenParticipantDeleted: boolean,
@@ -79,4 +76,13 @@ export interface Configuration {
     hubspotID: string,
     accessToken: string, 
     refreshToken: string
+}
+
+/**
+ * Database Access Tokens
+ */
+
+export interface IntegrationTokens {
+    accessToken: string;
+    refreshToken: string;
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -31,30 +31,47 @@ export function AddToDatabase(
         PushPartixipantsAsContacts = false,
         PullParticipantsIntoContacts = false,
 
-                                                     DeleteContactwhenParticipantDeleted = false, PushContactsAsParticipants = false,
-                                                     PullContactsIntoParticipants = false, DeleteParticipantWhenContactDeleted = false,
-                                                     accessToken = "", refreshToken = ""}) {
-    var key = hashValue(tenantAllias);
-    var id =  hashValue(hubspotID);
-    firebase.database().ref('keyTable/' + id + "/SasID").set({
-        ID: tenantAllias
-    });
-    firebase.database().ref('users/'+ key + '/saasquach' ).set({
-        PushPartixipantsAsContacts: PushPartixipantsAsContacts,
-        PullParticipantsIntoContacts : PullParticipantsIntoContacts,
-        DeleteContactwhenParticipantDeleted : DeleteContactwhenParticipantDeleted
-    });
-    firebase.database().ref('users/' + key + '/hubspot').set({
-        PushContactsAsParticipants : PushContactsAsParticipants,
-        PullContactsIntoParticipants : PullContactsIntoParticipants,
-        DeleteParticipantWhenContactDeleted : DeleteParticipantWhenContactDeleted
-    });
-    firebase.database().ref('users/' + key + '/userinfo').set({
-        tenantAllias: tenantAllias,
-        hubspotID: hubspotID,
-        accessToken: accessToken,
-        refreshToken: refreshToken
-    });
+        DeleteContactwhenParticipantDeleted = false,
+        PushContactsAsParticipants = false,
+        PullContactsIntoParticipants = false,
+        DeleteParticipantWhenContactDeleted = false,
+        accessToken = '',
+        refreshToken = '',
+    },
+) {
+    const key = hashValue(tenantAllias);
+    const id = hashValue(hubspotID);
+    firebase
+        .database()
+        .ref('keyTable/' + id + '/SasID')
+        .set({
+            ID: tenantAllias,
+        });
+    firebase
+        .database()
+        .ref('users/' + key + '/saasquach')
+        .set({
+            PushPartixipantsAsContacts: PushPartixipantsAsContacts,
+            PullParticipantsIntoContacts: PullParticipantsIntoContacts,
+            DeleteContactwhenParticipantDeleted: DeleteContactwhenParticipantDeleted,
+        });
+    firebase
+        .database()
+        .ref('users/' + key + '/hubspot')
+        .set({
+            PushContactsAsParticipants: PushContactsAsParticipants,
+            PullContactsIntoParticipants: PullContactsIntoParticipants,
+            DeleteParticipantWhenContactDeleted: DeleteParticipantWhenContactDeleted,
+        });
+    firebase
+        .database()
+        .ref('users/' + key + '/userinfo')
+        .set({
+            tenantAllias: tenantAllias,
+            hubspotID: hubspotID,
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+        });
 }
 
 /**
@@ -157,24 +174,31 @@ export function EditDatabase(
 }
 
 export async function PollDatabase(tenantAllias: string): Promise<Configuration> {
-	const key = hashValue(tenantAllias);
-	const databseRef = firebase.database().ref();
-	let configuration: Configuration = {
-		PushPartixipantsAsContacts: false,
-		PullParticipantsIntoContacts: false,
-		DeleteContactwhenParticipantDeleted: false,
-		PushContactsAsParticipants: false,
-		PullContactsIntoParticipants: false,
-		DeleteParticipantWhenContactDeleted: false,
+    const key = hashValue(tenantAllias);
+    const databseRef = firebase.database().ref();
+    const configuration: Configuration = {
+        PushPartixipantsAsContacts: false,
+        PullParticipantsIntoContacts: false,
+        DeleteContactwhenParticipantDeleted: false,
+        PushContactsAsParticipants: false,
+        PullContactsIntoParticipants: false,
+        DeleteParticipantWhenContactDeleted: false,
         hubspotID: '',
-		accessToken: '',
-		refreshToken: ''
-	};
-	await databseRef.child('users/' + key).get().then((snapshot) => {
-		if (snapshot.exists()) {
-			configuration.PushPartixipantsAsContacts = snapshot.child("saasquach/PushPartixipantsAsContacts").val();
-			configuration.PullParticipantsIntoContacts = snapshot.child("saasquach/PullParticipantsIntoContacts").val();
-			configuration.DeleteContactwhenParticipantDeleted = snapshot.child("saasquach/DeleteContactwhenParticipantDeleted").val();
+        accessToken: '',
+        refreshToken: '',
+    };
+    await databseRef
+        .child('users/' + key)
+        .get()
+        .then((snapshot) => {
+            if (snapshot.exists()) {
+                configuration.PushPartixipantsAsContacts = snapshot.child('saasquach/PushPartixipantsAsContacts').val();
+                configuration.PullParticipantsIntoContacts = snapshot
+                    .child('saasquach/PullParticipantsIntoContacts')
+                    .val();
+                configuration.DeleteContactwhenParticipantDeleted = snapshot
+                    .child('saasquach/DeleteContactwhenParticipantDeleted')
+                    .val();
 
                 configuration.PushContactsAsParticipants = snapshot.child('hubspot/PushContactsAsParticipants').val();
                 configuration.PullContactsIntoParticipants = snapshot
@@ -184,15 +208,15 @@ export async function PollDatabase(tenantAllias: string): Promise<Configuration>
                     .child('hubspot/DeleteParticipantWhenContactDeleted')
                     .val();
 
-			configuration.accessToken = snapshot.child("userinfo/accessToken").val();
-			configuration.refreshToken = snapshot.child("userinfo/refreshToken").val();
-            configuration.hubspotID = snapshot.child("userinfo/hubspotID").val();
-		} else
-			console.warn("No configuration data available!");
-	}).catch((error) => {
-		console.error(error);
-	});
-	return configuration;
+                configuration.accessToken = snapshot.child('userinfo/accessToken').val();
+                configuration.refreshToken = snapshot.child('userinfo/refreshToken').val();
+                configuration.hubspotID = snapshot.child('userinfo/hubspotID').val();
+            } else console.warn('No configuration data available!');
+        })
+        .catch((error) => {
+            console.error(error);
+        });
+    return configuration;
 }
 
 export async function LookupAllias(hubspotID: string): Promise<string> {
@@ -262,44 +286,53 @@ export async function PollTokensFromDatabase(tenantAllias: string): Promise<Inte
 
 /**
  * Used to store temporary user information
- * @param hubspotID 
- * @param accessToken 
- * @param refreshToken 
+ * @param hubspotID
+ * @param accessToken
+ * @param refreshToken
  */
-export function AddTempUser(hubspotID: string, accessToken = "", refreshToken = ""):void {
-    var key =  hashValue(hubspotID);
-    firebase.database().ref('tempUsers/'+ key ).set({
-        hubspotID : hubspotID,
-        accessToken : accessToken,
-        refreshToken : refreshToken,
-    });
+export function AddTempUser(hubspotID: string, accessToken = '', refreshToken = ''): void {
+    const key = hashValue(hubspotID);
+    firebase
+        .database()
+        .ref('tempUsers/' + key)
+        .set({
+            hubspotID: hubspotID,
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+        });
 }
 
 export function DeleteTempUser(hubspotID: string) {
-    var key = hashValue(hubspotID);
-    firebase.database().ref('tempUsers/' + key).remove();
+    const key = hashValue(hubspotID);
+    firebase
+        .database()
+        .ref('tempUsers/' + key)
+        .remove();
 }
-
 
 /**
  * Allowes us to read the values stored in the temporary user table
- * @param hubspotID 
+ * @param hubspotID
  * @returns { accessToken, refreshToken }
  *  Fields will be empty if it does not return
  */
-export async function PollTempUser(hubspotID: string):Promise<IntegrationTokens> {
-    var key = hashValue(hubspotID);
-    var databseRef = firebase.database().ref();
-    var data:IntegrationTokens = { accessToken: "", refreshToken: "" };
-    await databseRef.child('tempUsers/' + key).get().then((snapshot) => {
-        if (snapshot.exists()) {
-            data.accessToken =      snapshot.child("userinfo/accessToken").val();
-            data.refreshToken =     snapshot.child("userinfo/refreshToken").val();
-        } else {
-            console.log("No data available");
-        }
-    }).catch((error) => {
-        console.error(error);
-    });
+export async function PollTempUser(hubspotID: string): Promise<IntegrationTokens> {
+    const key = hashValue(hubspotID);
+    const databseRef = firebase.database().ref();
+    const data: IntegrationTokens = { accessToken: '', refreshToken: '' };
+    await databseRef
+        .child('tempUsers/' + key)
+        .get()
+        .then((snapshot) => {
+            if (snapshot.exists()) {
+                data.accessToken = snapshot.child('userinfo/accessToken').val();
+                data.refreshToken = snapshot.child('userinfo/refreshToken').val();
+            } else {
+                console.log('No data available');
+            }
+        })
+        .catch((error) => {
+            console.error(error);
+        });
     return data;
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,17 +1,16 @@
-import firebase from "firebase/app";
-import "firebase/database";
-import { Configuration } from "./Types/types";
-const crypto = require('crypto')
-
+import chalk from 'chalk';
+import firebase from 'firebase/app';
+import 'firebase/database';
+import { Configuration, IntegrationTokens } from './Types/types';
+const crypto = require('crypto');
 
 //#todo: The tenant alias is a number event after converting it to string
 //      the has function requires "data" argument must be of type
 //      string or an instance of Buffer, TypedArray, or DataView.
-function hashValue(stringValue: string){
-    stringValue.toString().toLowerCase()
+function hashValue(stringValue: string) {
+    stringValue.toString().toLowerCase();
     return crypto.createHash('sha1').update(stringValue).digest('hex');
 }
-
 
 /**
  * Adds Values to Database
@@ -25,7 +24,12 @@ function hashValue(stringValue: string){
  * PushContactsAsParticipants bool, PullContactsIntoParticipants bool, DeleteParticipantWhenContactDeleted bool
  * accessToken string, refreshToken string
  */
-export function AddToDatabase(tenantAllias: string, hubspotID: string, {PushPartixipantsAsContacts = false, PullParticipantsIntoContacts = false,
+export function AddToDatabase(
+    tenantAllias: string,
+    hubspotID: string,
+    {
+        PushPartixipantsAsContacts = false,
+        PullParticipantsIntoContacts = false,
 
                                                      DeleteContactwhenParticipantDeleted = false, PushContactsAsParticipants = false,
                                                      PullContactsIntoParticipants = false, DeleteParticipantWhenContactDeleted = false,
@@ -57,59 +61,99 @@ export function AddToDatabase(tenantAllias: string, hubspotID: string, {PushPart
  * Given a tenant alliase, deletes the coresponding db entry.
  * @param tenantAllias
  */
-export function DeleteFromDatabase(tenantAllias: string) {
-    var key = hashValue(tenantAllias);
-    firebase.database().ref('users/' + key).remove();
+export function DeleteFromDatabase(tenantAllias: string): void {
+    const key = hashValue(tenantAllias);
+    firebase
+        .database()
+        .ref('users/' + key)
+        .remove();
 }
 
-export function EditDatabase(tenantAllias: string, params : {PushPartixipantsAsContacts:Boolean,
-    PullParticipantsIntoContacts:Boolean, DeleteContactwhenParticipantDeleted:Boolean, PushContactsAsParticipants:Boolean,
-    PullContactsIntoParticipants:Boolean, DeleteParticipantWhenContactDeleted:Boolean, accessToken:String, refreshToken:String}) {
-    var key = hashValue(tenantAllias);
-    if(params.PushPartixipantsAsContacts != undefined){
-        firebase.database().ref('users/'+ key + '/saasquach' ).update({
-            PushPartixipantsAsContacts: params.PushPartixipantsAsContacts
-        });
+export function EditDatabase(
+    tenantAllias: string,
+    params: {
+        PushPartixipantsAsContacts: boolean;
+        PullParticipantsIntoContacts: boolean;
+        DeleteContactwhenParticipantDeleted: boolean;
+        PushContactsAsParticipants: boolean;
+        PullContactsIntoParticipants: boolean;
+        DeleteParticipantWhenContactDeleted: boolean;
+        accessToken: string;
+        refreshToken: string;
+    },
+): void {
+    const key = hashValue(tenantAllias);
+    if (params.PushPartixipantsAsContacts != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/saasquach')
+            .update({
+                PushPartixipantsAsContacts: params.PushPartixipantsAsContacts,
+            });
     }
-    if(params.PullParticipantsIntoContacts != undefined){
-        firebase.database().ref('users/'+ key + '/saasquach' ).update({
-            PullParticipantsIntoContacts : params.PullParticipantsIntoContacts
-        });
+    if (params.PullParticipantsIntoContacts != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/saasquach')
+            .update({
+                PullParticipantsIntoContacts: params.PullParticipantsIntoContacts,
+            });
     }
-    if(params.DeleteContactwhenParticipantDeleted != undefined){
-        firebase.database().ref('users/'+ key + '/saasquach' ).update({
-            DeleteContactwhenParticipantDeleted : params.DeleteContactwhenParticipantDeleted
-        });
+    if (params.DeleteContactwhenParticipantDeleted != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/saasquach')
+            .update({
+                DeleteContactwhenParticipantDeleted: params.DeleteContactwhenParticipantDeleted,
+            });
     }
-    if(params.PushContactsAsParticipants != undefined){
-        firebase.database().ref('users/' + key + '/hubspot').update({
-            PushContactsAsParticipants : params.PushContactsAsParticipants
-        });
+    if (params.PushContactsAsParticipants != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/hubspot')
+            .update({
+                PushContactsAsParticipants: params.PushContactsAsParticipants,
+            });
     }
 
-    if(params.PullContactsIntoParticipants != undefined){  
-        firebase.database().ref('users/' + key + '/hubspot').update({
-            PullContactsIntoParticipants : params.PullContactsIntoParticipants
-        });
+    if (params.PullContactsIntoParticipants != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/hubspot')
+            .update({
+                PullContactsIntoParticipants: params.PullContactsIntoParticipants,
+            });
     }
-    if(params.DeleteParticipantWhenContactDeleted != undefined){
-        firebase.database().ref('users/' + key + '/hubspot').update({
-            DeleteParticipantWhenContactDeleted : params.DeleteParticipantWhenContactDeleted
-        });
+    if (params.DeleteParticipantWhenContactDeleted != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/hubspot')
+            .update({
+                DeleteParticipantWhenContactDeleted: params.DeleteParticipantWhenContactDeleted,
+            });
     }
-    if(params.accessToken != undefined){
-        firebase.database().ref('users/' + key + '/userinfo').update({
-            accessToken: params.accessToken
-        });
+    if (params.accessToken != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/userinfo')
+            .update({
+                accessToken: params.accessToken,
+            });
     }
-    if(params.refreshToken != undefined){
-        firebase.database().ref('users/' + key + '/userinfo').update({
-            refreshToken: params.refreshToken
-        });
+    if (params.refreshToken != undefined) {
+        firebase
+            .database()
+            .ref('users/' + key + '/userinfo')
+            .update({
+                refreshToken: params.refreshToken,
+            });
     }
-    firebase.database().ref('users/' + key + '/userinfo').update({
-        tenantAllias: tenantAllias
-    });
+    firebase
+        .database()
+        .ref('users/' + key + '/userinfo')
+        .update({
+            tenantAllias: tenantAllias,
+        });
 }
 
 export async function PollDatabase(tenantAllias: string): Promise<Configuration> {
@@ -132,79 +176,89 @@ export async function PollDatabase(tenantAllias: string): Promise<Configuration>
 			configuration.PullParticipantsIntoContacts = snapshot.child("saasquach/PullParticipantsIntoContacts").val();
 			configuration.DeleteContactwhenParticipantDeleted = snapshot.child("saasquach/DeleteContactwhenParticipantDeleted").val();
 
-			configuration.PushContactsAsParticipants = snapshot.child("hubspot/PushContactsAsParticipants").val();
-			configuration.PullContactsIntoParticipants = snapshot.child("hubspot/PullContactsIntoParticipants").val();
-			configuration.DeleteParticipantWhenContactDeleted = snapshot.child("hubspot/DeleteParticipantWhenContactDeleted").val();
+                configuration.PushContactsAsParticipants = snapshot.child('hubspot/PushContactsAsParticipants').val();
+                configuration.PullContactsIntoParticipants = snapshot
+                    .child('hubspot/PullContactsIntoParticipants')
+                    .val();
+                configuration.DeleteParticipantWhenContactDeleted = snapshot
+                    .child('hubspot/DeleteParticipantWhenContactDeleted')
+                    .val();
 
 			configuration.accessToken = snapshot.child("userinfo/accessToken").val();
 			configuration.refreshToken = snapshot.child("userinfo/refreshToken").val();
             configuration.hubspotID = snapshot.child("userinfo/hubspotID").val();
 		} else
-			console.log("No configuration data available!");
+			console.warn("No configuration data available!");
 	}).catch((error) => {
 		console.error(error);
 	});
 	return configuration;
 }
 
-export async function LookupAllias(hubspotID: string) {
-    var key = hashValue(hubspotID);
-    var data = "";
-    var databseRef = firebase.database().ref();
-    await databseRef.child('keyTable/' + key).get().then((snapshot) => {
-        if (snapshot.exists()) {
-            data =  snapshot.child("SasID").val();
-        } else {
-            console.log("No data available");
-        }
-    }).catch((error) => {
-        console.error(error);
-    });
+export async function LookupAllias(hubspotID: string): Promise<string> {
+    const key = hashValue(hubspotID);
+    let data = '';
+    const databseRef = firebase.database().ref();
+    await databseRef
+        .child('keyTable/' + key)
+        .get()
+        .then((snapshot) => {
+            if (snapshot.exists()) {
+                data = snapshot.child('SasID').val();
+            } else {
+                console.warn('No data available');
+            }
+        })
+        .catch((error) => {
+            console.error(error);
+        });
     return data;
 }
-
 
 /**
  * Passing in a tenant alias as well as the access token and refresh token should update both, thoough the most
  * up to date version of both must be passed in. If only 1 needs to be changed, use the update fnction
  */
-export function AddTokensToDatabase(tenantAllias: string,  accessToken: string, refreshToken: string) {
-    var key = hashValue(tenantAllias);
-    firebase.database().ref('users/' + key + '/userinfo').set({
-        tenantAllias: tenantAllias,
-        accessToken: accessToken,
-        refreshToken: refreshToken
-    });
+export function AddTokensToDatabase(tenantAllias: string, accessToken: string, refreshToken: string): void {
+    const key = hashValue(tenantAllias);
+    firebase
+        .database()
+        .ref('users/' + key + '/userinfo')
+        .set({
+            tenantAllias: tenantAllias,
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+        });
 }
 
 /**
  * Retreives the stored access and refresh tokens for a given tenant allias. returns an object of the form
  * { accessToken, refreshToken } if the entry is available. If no entry is available, it will return two empty strings
  */
-export async function PollTokensFromDatabase(tenantAllias: string) {
-    var key = hashValue(tenantAllias);
+export async function PollTokensFromDatabase(tenantAllias: string): Promise<IntegrationTokens> {
+    const key = hashValue(tenantAllias);
 
-    var databseRef = firebase.database().ref();
-    var data = {
-        accessToken: "",
-        refreshToken: "",
+    const databseRef = firebase.database().ref();
+    const data: IntegrationTokens = {
+        accessToken: '',
+        refreshToken: '',
     };
-    await databseRef.child('users/' + key + '/userinfo').get().then((snapshot) => {
-        if (snapshot.exists()) {
-            data.accessToken =     snapshot.child("accessToken").val();
-            data.refreshToken =    snapshot.child("refreshToken").val();
-        } else {
-            console.log("No data available");
-        }
-    }).catch((error) => {
-        console.error(error);
-    });
+    await databseRef
+        .child('users/' + key + '/userinfo')
+        .get()
+        .then((snapshot) => {
+            if (snapshot.exists()) {
+                data.accessToken = snapshot.child('accessToken').val();
+                data.refreshToken = snapshot.child('refreshToken').val();
+            } else {
+                console.warn('No data available');
+            }
+        })
+        .catch((error) => {
+            console.error(error);
+        });
     return data;
 }
-
-
-
-
 
 /**
  * Used to store temporary user information
@@ -212,7 +266,7 @@ export async function PollTokensFromDatabase(tenantAllias: string) {
  * @param accessToken 
  * @param refreshToken 
  */
-export function AddTempUser(hubspotID: string, accessToken = "", refreshToken = "") {
+export function AddTempUser(hubspotID: string, accessToken = "", refreshToken = ""):void {
     var key =  hashValue(hubspotID);
     firebase.database().ref('tempUsers/'+ key ).set({
         hubspotID : hubspotID,
@@ -233,10 +287,10 @@ export function DeleteTempUser(hubspotID: string) {
  * @returns { accessToken, refreshToken }
  *  Fields will be empty if it does not return
  */
-export async function PollTempUser(hubspotID: string) {
+export async function PollTempUser(hubspotID: string):Promise<IntegrationTokens> {
     var key = hashValue(hubspotID);
     var databseRef = firebase.database().ref();
-    var data = { accessToken: "", refreshToken: "" };
+    var data:IntegrationTokens = { accessToken: "", refreshToken: "" };
     await databseRef.child('tempUsers/' + key).get().then((snapshot) => {
         if (snapshot.exists()) {
             data.accessToken =      snapshot.child("userinfo/accessToken").val();

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,19 @@ import path from 'path';
 import chalk from 'chalk';
 import routes from './routes';
 import oauthroutes from './routes/oath';
-import { configurationRoutes } from './routes/configuration'
+import { configurationRoutes } from './routes/configuration';
 import firebase from 'firebase/app';
 
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-  apiKey: "AIzaSyAbxaEk-eim7Y7jR8Cuv1mt_qk_v8Jg-O8",
-  authDomain: "integration-database-5dfe7.firebaseapp.com",
-  databaseURL: "https://integration-database-5dfe7-default-rtdb.firebaseio.com",
-  projectId: "integration-database-5dfe7",
-  storageBucket: "integration-database-5dfe7.appspot.com",
-  messagingSenderId: "1001945617105",
-  appId: "1:1001945617105:web:b32f8885a9d9e5224febf0",
-  measurementId: "G-VDBF663K1R"
+    apiKey: 'AIzaSyAbxaEk-eim7Y7jR8Cuv1mt_qk_v8Jg-O8',
+    authDomain: 'integration-database-5dfe7.firebaseapp.com',
+    databaseURL: 'https://integration-database-5dfe7-default-rtdb.firebaseio.com',
+    projectId: 'integration-database-5dfe7',
+    storageBucket: 'integration-database-5dfe7.appspot.com',
+    messagingSenderId: '1001945617105',
+    appId: '1:1001945617105:web:b32f8885a9d9e5224febf0',
+    measurementId: 'G-VDBF663K1R',
 };
 firebase.initializeApp(firebaseConfig);
 
@@ -24,12 +24,6 @@ import webhooks from './routes/webhooks';
 
 // constants
 const PORT = process.env.PORT || 8000;
-const {
-	HUBSPOT_API_KEY: HAPIKEY,
-	SAASQUATCH_API_KEY: SAPIKEY,
-	SAASQUATCH_TENANT_ALIAS: STENANTALIAS,
-  SERVER_TOKEN_SECRET: SERVER_TOKEN_SECRET,
-} = process.env;
 
 // configure
 const app = express();
@@ -49,17 +43,15 @@ app.use(configurationRoutes);
 app.use(webhooks);
 
 // static routes
-app.use(express.static(path.join(__dirname, '../public')))
+app.use(express.static(path.join(__dirname, '../public')));
 app.get('/', (_, res) => {
-	res.sendFile(path.join(__dirname, '../public', 'index.html'))
-})
+    res.sendFile(path.join(__dirname, '../public', 'index.html'));
+});
 app.get('*', (_, res) => {
-	res.redirect('/')
-})
+    res.redirect('/');
+});
 
 // launch
-app.listen(PORT, () => console.log(
-	chalk.bold('SaaSquatch-HubSpot') +
-	' integration listening on port ' +
-	chalk.blue.bold(PORT)
-))
+app.listen(PORT, () =>
+    console.log(chalk.bold('SaaSquatch-HubSpot') + ' integration listening on port ' + chalk.blue.bold(PORT)),
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const bodyParser = require('body-parser');
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
-const cookieParser = require("cookie-parser");
+const cookieParser = require('cookie-parser');
 app.use(cookieParser());
 
 // dynamic routes

--- a/src/integration/ConfigurationController.ts
+++ b/src/integration/ConfigurationController.ts
@@ -1,20 +1,24 @@
 /**
  * ConfigurationController
- * 
+ *
  * Includes utitlities for exposing configuration data to routes.
  */
 
-import { Configuration } from '../Types/types'
-import { ConfigurationModel } from './ConfigurationModel'
+import { Configuration } from '../Types/types';
+import { ConfigurationModel } from './ConfigurationModel';
 export class ConfigurationController {
-	public static async getConfiguration(userIdentifier: string) {
-		return ConfigurationModel.getConfiguration(userIdentifier)
-	}
-	public static async createConfiguration(userIdentifier: string, hubspotId: string, configuration: Configuration) {
-		return ConfigurationModel.createConfiguration(userIdentifier, hubspotId, configuration)
-	}
+    public static async getConfiguration(userIdentifier: string): Promise<Configuration> {
+        return ConfigurationModel.getConfiguration(userIdentifier);
+    }
+    public static async createConfiguration(
+        userIdentifier: string,
+        hubspotId: string,
+        configuration: Configuration,
+    ): Promise<void> {
+        return ConfigurationModel.createConfiguration(userIdentifier, hubspotId, configuration);
+    }
 
-	public static async updateConfiguration(userId: string, configuration: Configuration) {
-		return ConfigurationModel.updateConfiguration(userId, configuration)
-	}
+    public static async updateConfiguration(userId: string, configuration: Configuration): Promise<void> {
+        return ConfigurationModel.updateConfiguration(userId, configuration);
+    }
 }

--- a/src/integration/ConfigurationModel.ts
+++ b/src/integration/ConfigurationModel.ts
@@ -1,20 +1,20 @@
 /**
  * ConfigurationModel
- * 
+ *
  * Stores/manages information about a specific integration's configuration.
  * The current implementation only exposes a configuration for a single user.
  * This should be changed when session-management is implemented.
- * 
+ *
  * See also: ConfigurationController (for network-based interaction with a user's configuration)
  */
 
-import { Configuration } from '../Types/types'
-import { PollDatabase } from '../database'
-import { AddToDatabase } from '../database'
-import { EditDatabase } from '../database'
+import { Configuration } from '../Types/types';
+import { PollDatabase } from '../database';
+import { AddToDatabase } from '../database';
+import { EditDatabase } from '../database';
 
 export class ConfigurationModel {
-	/*
+    /*
 	static configuration: Configuration = {
 
 		PushPartixipantsAsContacts: false, 
@@ -27,15 +27,19 @@ export class ConfigurationModel {
 		refreshToken: ""
 	}*/
 
-	public static async getConfiguration(userId: string): Promise<Configuration> {
-		return PollDatabase(userId);
-	}
+    public static async getConfiguration(userId: string): Promise<Configuration> {
+        return PollDatabase(userId);
+    }
 
-	public static async createConfiguration(userId: string, hubspotId: string, configuration: Configuration): Promise<void> {
-		return AddToDatabase(userId, hubspotId, configuration);
-	}
+    public static async createConfiguration(
+        userId: string,
+        hubspotId: string,
+        configuration: Configuration,
+    ): Promise<void> {
+        return AddToDatabase(userId, hubspotId, configuration);
+    }
 
-	public static async updateConfiguration(userId: string, configuration: Configuration): Promise<void> {
-		return EditDatabase(userId, configuration);
-	}
+    public static async updateConfiguration(userId: string, configuration: Configuration): Promise<void> {
+        return EditDatabase(userId, configuration);
+    }
 }

--- a/src/integration/HubspotApiModel.ts
+++ b/src/integration/HubspotApiModel.ts
@@ -1,50 +1,47 @@
-import axios from "axios";
-import {get_current_user} from "../routes/oath";
-import {PollTokensFromDatabase} from "../database";
+import axios from 'axios';
+import { get_current_user } from '../routes/oath';
+import { PollTokensFromDatabase } from '../database';
+import { IntegrationTokens } from '../Types/types';
 
 /**
  * This is the model between the HubSpot API and our controller.
  */
 
 export class HubspotApiModel {
-
     /**
      * Gets contact from HubSpot.
-     * 
+     *
      * @param objectId objectID of contact to query
      * @param paramToGet query parameters to filter by. eg. 'email'.
      */
-    public async getContact(contactObjectID: number, paramToGet?: string){
-        console.log("this is current user ", get_current_user());
-        let token:any = await PollTokensFromDatabase(get_current_user());
-        let access_token = token.accessToken;
+    public async getContact(contactObjectID: number, paramToGet?: string): Promise<any> {
+        const token: IntegrationTokens = await PollTokensFromDatabase(get_current_user());
+        const access_token = token.accessToken;
         const url = `https://api.hubapi.com/crm/v3/objects/contacts/${encodeURIComponent(contactObjectID)}`;
 
-        let options:any = {
-            qs: {"properties": 'email', "archived": 'false'},
-            headers: {accept: 'application/json',authorization:`Bearer ${access_token}`}
+        let options: any = {
+            qs: { properties: 'email', archived: 'false' },
+            headers: { accept: 'application/json', authorization: `Bearer ${access_token}` },
         };
-        if (paramToGet){
+        if (paramToGet) {
             options = {
-               qs: {"properties": 'email', "archived": 'false'},
-               headers:{ accept: 'application/json',authorization:`Bearer ${access_token}`}
+                qs: { properties: 'email', archived: 'false' },
+                headers: { accept: 'application/json', authorization: `Bearer ${access_token}` },
+            };
+        } else {
+            options = {
+                qs: { archived: 'false' },
+                headers: { accept: 'application/json', authorization: `Bearer ${access_token}` },
             };
         }
-        else{
-            options = {
-                qs: {"archived": 'false'},
-                headers:{accept: 'application/json',authorization:`Bearer ${access_token}`}
-            };
-        }
-        try{
+        try {
             const resp = await axios.get(url, options);
             if (resp.status != 200) {
-                throw Error("Error getting a contact from HubSpot." + resp.data["error"]);
-            }
-            else{
+                throw Error('Error getting a contact from HubSpot.' + resp.data['error']);
+            } else {
                 return resp.data;
             }
-        }catch(e){
+        } catch (e) {
             console.error(e);
         }
     }
@@ -56,62 +53,60 @@ export class HubspotApiModel {
      * @param createObjectBody body specifiying the create properties of the object
      * @returns axios response
      */
-    public async createObject(objectType:string, createObjectBody:object){
-        let token:any = await PollTokensFromDatabase(get_current_user());
-        let access_token = token.accessToken;
+    public async createObject(objectType: string, createObjectBody: any): Promise<any> {
+        const token: IntegrationTokens = await PollTokensFromDatabase(get_current_user());
+        const access_token = token.accessToken;
 
-        try{
+        try {
             const createObjectURL = 'https://api.hubapi.com/crm/v3/objects/' + objectType;
-            const response = await axios.post(createObjectURL, createObjectBody,{
+            const response = await axios.post(createObjectURL, createObjectBody, {
                 params: {
-                    headers:{ accept: 'application/json',authorization:`Bearer ${access_token}`}
-                }
+                    headers: { accept: 'application/json', authorization: `Bearer ${access_token}` },
+                },
             });
             return response;
         } catch (e) {
-            console.error("Was not able to create contact");
-            console.log(e);
-            return JSON.parse(e.response.body);
+            console.error('Was not able to create contact');
+            console.error(e);
         }
     }
 
     /**
-     * 
-     * @param objectType object to create property to check property for 
+     *
+     * @param objectType object to create property to check property for
      * @param propertyName the name of the property, not the label
      * @returns true if the property exists, otherwise false
      */
-    public async objectHasProperty(objectType: string, propertyName: string){
-        let token:any = await PollTokensFromDatabase(get_current_user());
-        let access_token = token.accessToken;
+    public async objectHasProperty(objectType: string, propertyName: string): Promise<any> {
+        const token: IntegrationTokens = await PollTokensFromDatabase(get_current_user());
+        const access_token = token.accessToken;
 
-        const readPropertyURL = 'https://api.hubapi.com/crm/v3/properties/' + objectType + '/' + propertyName; 
+        const readPropertyURL = 'https://api.hubapi.com/crm/v3/properties/' + objectType + '/' + propertyName;
         try {
-         const response = await axios.get(readPropertyURL, {
-             params: {
-                headers:{ accept: 'application/json',authorization:`Bearer ${access_token}`}
-            }
-         });
-            if (response.status==200 ){
-                return true; 
+            const response = await axios.get(readPropertyURL, {
+                params: {
+                    headers: { accept: 'application/json', authorization: `Bearer ${access_token}` },
+                },
+            });
+            if (response.status == 200) {
+                return true;
             } else {
-                console.error("======== WAS NOT ABLE TO READ PROPERTY ========");
+                console.error('======== WAS NOT ABLE TO READ PROPERTY ========');
                 console.error(response);
             }
         } catch (e) {
-            if(e.response.status==404){
+            if (e.response.status == 404) {
                 return false;
-            } else{
-                console.error("======== WAS NOT ABLE TO MAKE CALL: STATUS CODE: "+ e.response.status+" ========");
-                console.log(e);
-                return JSON.parse(e.response.body);
+            } else {
+                console.error('======== WAS NOT ABLE TO MAKE CALL: STATUS CODE: ' + e.response.status + ' ========');
+                console.error(e);
             }
         }
     }
 
     /**
      * Create a hubspot property for an object
-     * 
+     *
      * @param objectType object to create property for
      * @param propertyName The internal property name, which must be used when referencing the property via the (hubspot's) API.
      * @param propertyLabel A human-readable property label that will be shown in HubSpot.
@@ -120,29 +115,35 @@ export class HubspotApiModel {
      * @param propertyGroupName The name of the property group the property belongs to.
      * https://developers.hubspot.com/docs/api/crm/properties
      */
-    public async createObjectProperty(objectType:string, propertyName: string, propertyLabel:string, propertyType:string, propertyFieldType:string, propertyGroupName: string){
-        let token:any = await PollTokensFromDatabase(get_current_user());
-        let access_token = token.accessToken;
+    public async createObjectProperty(
+        objectType: string,
+        propertyName: string,
+        propertyLabel: string,
+        propertyType: string,
+        propertyFieldType: string,
+        propertyGroupName: string,
+    ): Promise<any> {
+        const token: IntegrationTokens = await PollTokensFromDatabase(get_current_user());
+        const access_token = token.accessToken;
 
         const contactCreatePropertyURL = 'https://api.hubapi.com/crm/v3/properties/' + objectType;
         const body = {
-            "name": propertyName,
-            "label": propertyLabel,
-            "type": propertyType,
-            "fieldType": propertyFieldType,
-            "groupName": propertyGroupName,
-            "formField": true
+            name: propertyName,
+            label: propertyLabel,
+            type: propertyType,
+            fieldType: propertyFieldType,
+            groupName: propertyGroupName,
+            formField: true,
         };
         try {
             await axios.post(contactCreatePropertyURL, body, {
                 params: {
-                    headers:{ accept: 'application/json',authorization:`Bearer ${access_token}`}
-                }
-            })
+                    headers: { accept: 'application/json', authorization: `Bearer ${access_token}` },
+                },
+            });
         } catch (e) {
-            console.error("==== WAS NOT ABLE TO POST NEW PROPERTY ===");
-            console.log(e);
-            return JSON.parse(e.response.body);
+            console.error('==== WAS NOT ABLE TO POST NEW PROPERTY ===');
+            console.error(e);
         }
     }
 
@@ -152,24 +153,22 @@ export class HubspotApiModel {
      * @param body body specifiying the search properties of the object
      * @returns axios response
      */
-    public async searchObject(objectType:string, body:object){
-
+    public async searchObject(objectType: string, body: any): Promise<any> {
         const searchObjectURL = 'https://api.hubapi.com/crm/v3/objects/' + objectType + '/search';
-        console.log("this is current user ", get_current_user());
-        let token:any = await PollTokensFromDatabase(get_current_user());
-        let access_token = token.accessToken;
+        console.log('this is current user ', get_current_user());
+        const token: IntegrationTokens = await PollTokensFromDatabase(get_current_user());
+        const access_token = token.accessToken;
 
         try {
-            const response = await axios.post(searchObjectURL,body, {
+            const response = await axios.post(searchObjectURL, body, {
                 params: {
-                    headers:{ accept: 'application/json',authorization:`Bearer ${access_token}`}
-            }});
+                    headers: { accept: 'application/json', authorization: `Bearer ${access_token}` },
+                },
+            });
             return response;
         } catch (e) {
-            console.error("===== WAS NOT ABLE TO SEARCH FOR PROPERTIES OF OBJECT: " + objectType);
+            console.error('===== WAS NOT ABLE TO SEARCH FOR PROPERTIES OF OBJECT: ' + objectType);
             console.error(e);
-            return JSON.parse(e.response.body);
         }
     }
-   
 }

--- a/src/integration/SaasquatchApiModel.ts
+++ b/src/integration/SaasquatchApiModel.ts
@@ -1,13 +1,11 @@
-import axios from "axios";
+import axios from 'axios';
 
 export class SaasquatchApiModel {
-
-    
     // Temp access until DB has OAuth access tokens
     private SAPIKEY: string;
     private TENANTALIAS: string;
 
-    constructor(apiKey: string, tenantAlias: string){
+    constructor(apiKey: string, tenantAlias: string) {
         this.SAPIKEY = apiKey;
         this.TENANTALIAS = tenantAlias;
     }
@@ -15,58 +13,59 @@ export class SaasquatchApiModel {
     /**
      * Get users from SaaSquatch that match paramToFilterBy
      * Currently gets all users or zero users as filter is not working
-     * 
+     *
      * @param paramToFilterBy list of query parameters to filter by. eg. 'email:example@example.com'?
      */
-    public async getUsers(paramToFilterBy?: string){
+    public async getUsers(paramToFilterBy?: string): Promise<any> {
         const headers = { accept: 'application/json' };
         const url = `https://staging.referralsaasquatch.com/api/v1/${encodeURIComponent(this.TENANTALIAS)}/users`;
         let qs = '';
-        if (paramToFilterBy){
+        if (paramToFilterBy) {
             qs = paramToFilterBy;
         }
         try {
-            const resp = await axios.get( url, { 
-                params: { 
+            const resp = await axios.get(url, {
+                params: {
                     query: qs,
                     limit: 10,
-                    offset: 0
-                }, 
+                    offset: 0,
+                },
                 headers: headers,
                 auth: {
                     username: '',
-                    password: this.SAPIKEY
-                }
-             } );
+                    password: this.SAPIKEY,
+                },
+            });
             if (resp.status != 200) {
-                throw Error("Error getting a contact from SaaSquatch." + resp.data["error"]);
-            }
-            else{
+                throw Error('Error getting a contact from SaaSquatch.' + resp.data['error']);
+            } else {
                 console.log(resp);
                 return resp.data;
             }
-        } catch(e){
+        } catch (e) {
             console.error(e);
         }
+    }
+
+    public async createParticipant(email: string, createParticipantBody: any) {
+        try {
+            //URL should be built using express URL class
+            const createParticipantURL =
+                'https://staging.referralsaasquatch.com/api/v1/' +
+                this.TENANTALIAS +
+                '/open/account/' +
+                email +
+                '/user/' +
+                email;
+            const response = await axios.post(createParticipantURL, createParticipantBody, {
+                headers: {
+                    Authorization: 'token ' + this.SAPIKEY,
+                },
+            });
+            return response;
+        } catch (e) {
+            console.error('Was not able to create contact');
+            console.log(e);
         }
-
-        public async createParticipant(email:string, createParticipantBody:object){
-            try{
-                //URL should be built using express URL class
-                const createParticipantURL = 'https://staging.referralsaasquatch.com/api/v1/' +this.TENANTALIAS+ '/open/account/' + email + '/user/' + email;
-                const response = await axios.post(createParticipantURL, createParticipantBody,{
-                    headers: {
-                      'Authorization':'token '+this.SAPIKEY
-                  }
-                  });
-                return response;
-            } catch (e) {
-                console.error("Was not able to create contact");
-                console.log(e);
-            }
-        }
-
-
-   
-
+    }
 }

--- a/src/integration/hubspotUpdatesController.ts
+++ b/src/integration/hubspotUpdatesController.ts
@@ -1,12 +1,11 @@
-import { HubspotPayload } from "../Types/types";
-import { HubspotApiModel } from "./HubspotApiModel";
-import { SaasquatchApiModel } from "./SaasquatchApiModel";
+import { HubspotPayload } from '../Types/types';
+import { HubspotApiModel } from './HubspotApiModel';
+import { SaasquatchApiModel } from './SaasquatchApiModel';
 
-
-export class hubspotUpdatesController{
+export class hubspotUpdatesController {
     private hubApiModel: HubspotApiModel;
     private saasApiModel: SaasquatchApiModel;
-    constructor( sApiKey: string, sTenantAlias: string){
+    constructor(sApiKey: string, sTenantAlias: string) {
         this.saasApiModel = new SaasquatchApiModel(sApiKey, sTenantAlias);
         this.hubApiModel = new HubspotApiModel();
     }
@@ -15,63 +14,51 @@ export class hubspotUpdatesController{
      * Received webhook of subscription type 'contact.created'
      * @param hubspotPayload Payload of Hubspot webhook
      */
-    public NewContact(hubspotPayload: HubspotPayload){
+    public NewContact(hubspotPayload: HubspotPayload): void {
         console.log('received HubSpot contact.creation');
-        
+
         const contactObjectId: number = hubspotPayload.objectId;
-        console.log("New contact obj id: "+contactObjectId);
-    
+
         // Hubspot does not include email in contact.created
         // Get new contact's email
-        let params ='';
-        this.hubApiModel.getContact(contactObjectId)
-        .then(data =>{
-            console.log("response");
-            console.log(data);
+        let params = '';
+        this.hubApiModel.getContact(contactObjectId).then((data) => {
+            //console.log(data);
             const participant = data;
             params = `email:${encodeURIComponent(data.properties.email)}`;
-            console.log("PARAMS");
-            console.log(params);
+            //console.log(params);
             // 1. Check if contact exists as user in SaaSquatch (match by email)
-            this.saasApiModel.getUsers(params)
-            .then( data =>{
+            this.saasApiModel.getUsers(params).then((data) => {
                 //If it does not exist, create new user in SaaSquatch
-                if(data.count == 0){
-                    console.log("User does not exist in SaaSquatch");
+                if (data.count == 0) {
+                    //console.log('User does not exist in SaaSquatch');
                     const createParticipantBody = {
-                            "email": participant.properties.email,
-                            "firstName": participant.properties.firstname,
-                            "lastName": participant.properties.lastname,
-                            "id": participant.properties.email,
-						    "accountId": participant.properties.email,
-            
+                        email: participant.properties.email,
+                        firstName: participant.properties.firstname,
+                        lastName: participant.properties.lastname,
+                        id: participant.properties.email,
+                        accountId: participant.properties.email,
                     };
                     this.saasApiModel.createParticipant(participant.properties.email, createParticipantBody);
                 }
                 // 3. TODO: If it does exist, get share link and other relevant data
-                else{
-                    console.log("SAAS USER "+data.users[0].email);
-                    console.log("user share links: "+data.users[0].shareLinks);
+                else {
+                    //console.log('SAAS USER ' + data.users[0].email);
+                    //console.log('user share links: ' + data.users[0].shareLinks);
                 }
                 // 4. TODO: send referral link back to hubspot to add to contact
-            
-                }
-    
-            );
+            });
         });
         //console.log("contact email: "+ contactEmail);
         // const params = `email:${contactEmail}`;
-        console.log(params);
     }
-    
-    
-    
+
     /**
      * Received webhook of subscription type 'contact.deletion'
      * @param hubspotPayload Payload of Hubspot webhook
      */
-    public DeletedContact(hubspotPayload: HubspotPayload){
-        console.log('received HubSpot contact.deletion');
+    public DeletedContact(hubspotPayload: HubspotPayload): void {
+        console.log('received HubSpot contact.deletion: ' + hubspotPayload);
         /**
          * TODO:
          * Steps
@@ -81,14 +68,13 @@ export class hubspotUpdatesController{
          * 4. Done?
          */
     }
-    
-    
+
     /**
      * Received webhook of subscription type 'contact.propertyChange'
      * @param hubspotPayload Payload of Hubspot webhook
      */
-    public ChangedContact(hubspotPayload: HubspotPayload){
-        console.log('received HubSpot contact.propertyChange');
+    public ChangedContact(hubspotPayload: HubspotPayload): void {
+        console.log('received HubSpot contact.propertyChange: ' + hubspotPayload);
         /**
          * TODO:
          * Steps
@@ -98,6 +84,4 @@ export class hubspotUpdatesController{
          * 4. Done?
          */
     }
-
-
 }

--- a/src/integration/saasquatchUpdatesController.ts
+++ b/src/integration/saasquatchUpdatesController.ts
@@ -1,80 +1,76 @@
-import { str } from "ajv";
-import { SaasquatchPayload } from "../Types/types";
-import { HubspotApiModel } from "./HubspotApiModel";
-import { SaasquatchApiModel } from "./SaasquatchApiModel";
+import { SaasquatchPayload } from '../Types/types';
+import { HubspotApiModel } from './HubspotApiModel';
+import { SaasquatchApiModel } from './SaasquatchApiModel';
 
-export class saasquatchUpdatesController{
-
+export class saasquatchUpdatesController {
     private hubApiModel: HubspotApiModel;
     private saasApiModel: SaasquatchApiModel;
 
-
-     constructor(hApiKey: string, sApiKey: string, sTenantAlias: string){
+    constructor(hApiKey: string, sApiKey: string, sTenantAlias: string) {
         this.saasApiModel = new SaasquatchApiModel(sApiKey, sTenantAlias);
         this.hubApiModel = new HubspotApiModel();
-     }
-
-
+    }
 
     /**
      * Received webhook of event type 'user.created'
      * @param saasquatchPayload Payload of SaaSquatch webhook
      */
-    public async NewUser(saasquatchPayload: any){
-        console.log('Received SaaSquatch user.created.');
-        console.log(saasquatchPayload);
+    public async NewUser(saasquatchPayload: SaasquatchPayload) {
+        //console.log('Received SaaSquatch user.created.');
         const saasquatchPayloadData = saasquatchPayload.data;
         const contactsSearchBody = {
             filterGroups: [
                 {
                     filters: [
-                    {
-                      "value": saasquatchPayloadData.email, 
-                      "propertyName": 'email', 
-                      "operator": 'EQ'
-                  }
-                   ]
-                  }
-              ],
-              limit: 1,
-
+                        {
+                            value: saasquatchPayloadData.email,
+                            propertyName: 'email',
+                            operator: 'EQ',
+                        },
+                    ],
+                },
+            ],
+            limit: 1,
         };
-        const contactsSearchResponse = await this.hubApiModel.searchObject("contacts", contactsSearchBody);
-         if (contactsSearchResponse?.data.total == 0){
-            var programShareLinks: { [key: string]: any } = {};
-            for (const key in saasquatchPayloadData.programShareLinks){
-                let newProgramShareLinkName = key.replace(/\W/g, '') + "saasquatch_program";
-                let newProgramShareLinkLabel = key.replace(/\W/g, '') + " Saasquatch Program";
-                if(!await this.hubApiModel.objectHasProperty("contacts", newProgramShareLinkName)){
-                    await this.hubApiModel.createObjectProperty("contacts", newProgramShareLinkName, newProgramShareLinkLabel, "string", "textarea", "contactinformation");
+        const contactsSearchResponse = await this.hubApiModel.searchObject('contacts', contactsSearchBody);
+        if (contactsSearchResponse?.data.total == 0) {
+            const programShareLinks: { [key: string]: any } = {};
+            for (const key in saasquatchPayloadData.programShareLinks) {
+                const newProgramShareLinkName = key.replace(/\W/g, '') + 'saasquatch_program';
+                const newProgramShareLinkLabel = key.replace(/\W/g, '') + ' Saasquatch Program';
+                if (!(await this.hubApiModel.objectHasProperty('contacts', newProgramShareLinkName))) {
+                    await this.hubApiModel.createObjectProperty(
+                        'contacts',
+                        newProgramShareLinkName,
+                        newProgramShareLinkLabel,
+                        'string',
+                        'textarea',
+                        'contactinformation',
+                    );
                 }
-                programShareLinks[newProgramShareLinkName] = saasquatchPayloadData.programShareLinks[key].cleanShareLink;
-               };
-              
-               
-               const basicContactInfo = {
-                "email": saasquatchPayloadData.email,
-                "firstname": saasquatchPayloadData.firstName,
-                "lastname": saasquatchPayloadData.lastName,
+                programShareLinks[newProgramShareLinkName] =
+                    saasquatchPayloadData.programShareLinks[key].cleanShareLink;
             }
+
+            const basicContactInfo = {
+                email: saasquatchPayloadData.email,
+                firstname: saasquatchPayloadData.firstName,
+                lastname: saasquatchPayloadData.lastName,
+            };
             const basicInfoAndProgramShareLinks = Object.assign(basicContactInfo, programShareLinks);
             const createContactBody = {
-                "properties": basicInfoAndProgramShareLinks
-            }
-            await this.hubApiModel.createObject("contacts", createContactBody);
-               
-            
-         }
+                properties: basicInfoAndProgramShareLinks,
+            };
+            await this.hubApiModel.createObject('contacts', createContactBody);
+        }
     }
-
 
     /**
      * Received webhook of event type 'test'. No processing required as this is a test webhook.
-     * 
+     *
      * @param saasquatchPayload Payload of SaaSquatch webhook
      */
-    public Test(saasquatchPayload: SaasquatchPayload){
-        console.log('Received SaaSquatch test webhook.');  
+    public Test(saasquatchPayload: SaasquatchPayload): void {
+        console.info('Received SaaSquatch test webhook:' + saasquatchPayload);
     }
-
 }

--- a/src/jest/setEnvVars.ts
+++ b/src/jest/setEnvVars.ts
@@ -1,4 +1,4 @@
 /**
  * Fake env variables for testing purposes
  */
- // process.env.HUBSPOT_CLIENT_SECRET = '12345-ABCDE-12345-ABCDE'
+// process.env.HUBSPOT_CLIENT_SECRET = '12345-ABCDE-12345-ABCDE'

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -1,6 +1,6 @@
 // This file is used to store hard-coded constants for things that half-work.
 
 // Replaces an integration users's ID, since sessions are not implemented.
-export const MOCK_SESSION_USER_EMAIL: string = 'testUser@example.com'
-export const MOCK_SESSION_USER_ID: string = "test_abmacfbsumae1"
-export const MOCK_SESSION_HUBSPOT_ID: string = "308099"
+export const MOCK_SESSION_USER_EMAIL = 'testUser@example.com';
+export const MOCK_SESSION_USER_ID = 'test_abmacfbsumae1';
+export const MOCK_SESSION_HUBSPOT_ID = '308099';

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -1,22 +1,19 @@
-import Ajv from 'ajv'
-import ConfigurationPayloadSchema from '../Types/configuration-payload-schema.json'
+import Ajv from 'ajv';
+import ConfigurationPayloadSchema from '../Types/configuration-payload-schema.json';
 
-import { Router } from 'express'
-import { Configuration } from '../Types/types'
-import { ConfigurationController } from '../integration/ConfigurationController'
-import { authenticateToken } from './oath'
+import { Router } from 'express';
+import { Configuration } from '../Types/types';
+import { ConfigurationController } from '../integration/ConfigurationController';
+import { authenticateToken } from './oath';
 
-import {
-	MOCK_SESSION_USER_ID,
-	MOCK_SESSION_HUBSPOT_ID,
-} from '../mock'
+import { MOCK_SESSION_USER_ID, MOCK_SESSION_HUBSPOT_ID } from '../mock';
 
-const router = Router()
-const ajv = new Ajv()
+const router = Router();
+const ajv = new Ajv();
 
-const validate =  ajv.compile(ConfigurationPayloadSchema)
+const validate = ajv.compile(ConfigurationPayloadSchema);
 
-const API_CONFIGURATION_URL = '/api/configuration'
+const API_CONFIGURATION_URL = '/api/configuration';
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
@@ -74,4 +71,4 @@ router.put(API_CONFIGURATION_URL, async (req, res) => {
 	}
 })
 
-export { router as configurationRoutes }
+export { router as configurationRoutes };

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -16,59 +16,59 @@ const validate = ajv.compile(ConfigurationPayloadSchema);
 const API_CONFIGURATION_URL = '/api/configuration';
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
-	let decoded = undefined
-	if(req.cookies.frontendToken) {
-		decoded = authenticateToken(req.cookies.frontendToken as string)
-	}
-	if (decoded != undefined) {
-		const configuration = await ConfigurationController.getConfiguration(MOCK_SESSION_USER_ID)
-		res.json(configuration)
-		res.end();
-	} else {
-		console.error(`GET ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`)
-		res.sendStatus(400);
-		res.end();
-	}
-})
+    let decoded = undefined;
+    if (req.cookies.frontendToken) {
+        decoded = authenticateToken(req.cookies.frontendToken as string);
+    }
+    if (decoded != undefined) {
+        const configuration = await ConfigurationController.getConfiguration(MOCK_SESSION_USER_ID);
+        res.json(configuration);
+        res.end();
+    } else {
+        console.error(`GET ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`);
+        res.sendStatus(400);
+        res.end();
+    }
+});
 router.post(API_CONFIGURATION_URL, async (req, res) => {
-	let decoded = undefined
-	if(req.cookies.frontendToken) {
-		decoded = authenticateToken(req.cookies.frontendToken as string)
-	}
-	if(validate(req.body) && decoded != undefined) {
-		const configuration: Configuration = req.body as Configuration
-		ConfigurationController.createConfiguration(MOCK_SESSION_USER_ID, MOCK_SESSION_HUBSPOT_ID, configuration)
-		res.sendStatus(200)
-		res.end()
-	} else if (!validate(req.body)) {
-		console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate response body`)
-		res.sendStatus(400);
-		res.end();
-	} else if (decoded === undefined) {
-		console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`)
-		res.sendStatus(400);
-		res.end();
-	}
-})
+    let decoded = undefined;
+    if (req.cookies.frontendToken) {
+        decoded = authenticateToken(req.cookies.frontendToken as string);
+    }
+    if (validate(req.body) && decoded != undefined) {
+        const configuration: Configuration = req.body as Configuration;
+        ConfigurationController.createConfiguration(MOCK_SESSION_USER_ID, MOCK_SESSION_HUBSPOT_ID, configuration);
+        res.sendStatus(200);
+        res.end();
+    } else if (!validate(req.body)) {
+        console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate response body`);
+        res.sendStatus(400);
+        res.end();
+    } else if (decoded === undefined) {
+        console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`);
+        res.sendStatus(400);
+        res.end();
+    }
+});
 router.put(API_CONFIGURATION_URL, async (req, res) => {
-	let decoded = undefined
-	if(req.cookies.frontendToken) {
-		decoded = authenticateToken(req.cookies.frontendToken as string)
-	}
-	if(validate(req.body) && decoded != undefined) {
-		const configuration: Configuration = req.body as Configuration
-		ConfigurationController.updateConfiguration(MOCK_SESSION_USER_ID, configuration)
-		res.sendStatus(200)
-		res.end()
-	} else if (!validate(req.body)) {
-		console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate response body`)
-		res.sendStatus(400);
-		res.end();
-	} else if (decoded === undefined){
-		console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`)
-		res.sendStatus(400);
-		res.end();
-	}
-})
+    let decoded = undefined;
+    if (req.cookies.frontendToken) {
+        decoded = authenticateToken(req.cookies.frontendToken as string);
+    }
+    if (validate(req.body) && decoded != undefined) {
+        const configuration: Configuration = req.body as Configuration;
+        ConfigurationController.updateConfiguration(MOCK_SESSION_USER_ID, configuration);
+        res.sendStatus(200);
+        res.end();
+    } else if (!validate(req.body)) {
+        console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate response body`);
+        res.sendStatus(400);
+        res.end();
+    } else if (decoded === undefined) {
+        console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`);
+        res.sendStatus(400);
+        res.end();
+    }
+});
 
 export { router as configurationRoutes };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,51 +1,44 @@
-import { Router } from 'express'
-import axios from 'axios'
-import http from 'http'
-import chalk from 'chalk'
+import { Router } from 'express';
+import axios from 'axios';
 import * as dotenv from 'dotenv';
-import { listenerCount } from 'events';
 dotenv.config();
 
-import {HubApiCall} from "./oath";
+import { HubApiCall } from './oath';
 
 //#todo: probably replace the line below with a DB import when the DB is ready
-import {tokenStore} from "./oath";
-
-
-
-
+import { tokenStore } from './oath';
 
 //ensures that API keys are accessible THIS Will be replaced by OATH
 if (!process.env.HAPIKEY || !process.env.SAPIKEY || !process.env.STENANTALIAS) {
-    throw new Error('Missing HAPIKEY environment variable.')
+    throw new Error('Missing HAPIKEY environment variable.');
 }
 
 const HAPIKEY = process.env.HAPIKEY;
 const SAPIKEY = process.env.SAPIKEY;
 const STENANTALIAS = process.env.STENANTALIAS;
 
-const router = Router()
+const router = Router();
 router.get('/api/', (_, res) => {
-	res.setHeader('content-type', 'application/json')
-	res.end(JSON.stringify({
-		apiVersion: 1,
-		documentation: 'https://github.com/SENG499-team-2/SaaSquatch-HubSpot-integration'
-	}))
-})
+    res.setHeader('content-type', 'application/json');
+    res.end(
+        JSON.stringify({
+            apiVersion: 1,
+            documentation: 'https://github.com/SENG499-team-2/SaaSquatch-HubSpot-integration',
+        }),
+    );
+});
 
 //checks the JSON identity item returned from hubspot is infact an email
 // TODO
 // - it would be nice to validate that the string is in email format
-async function isHubspotEmail(identities: any){
-
-	try {
-		if (identities['type'] === 'EMAIL'){
-			return true;
-		}
-		else{
-			return false;
-		}
-	} catch (e) {
+async function isHubspotEmail(identities: any) {
+    try {
+        if (identities['type'] === 'EMAIL') {
+            return true;
+        } else {
+            return false;
+        }
+    } catch (e) {
         console.error('  > Unable to retrieve contact');
         return e;
     }
@@ -60,46 +53,45 @@ async function isHubspotEmail(identities: any){
 //	- Parsing the JSON shouldn't rely on hardcoding the value locations
 //	- Use Oauth to post instead of API key
 async function postContacts(contact: any) {
-	try {
-		console.log('EMAIL:' + contact['identity-profiles'][0]['identities'][0]['value']);
-		const identities = contact['identity-profiles'][0]['identities']
-		if (identities){
-			if (isHubspotEmail(identities[0])){
-				//can be just dot mo [']
-				const firstName = contact['properties']['firstname']['value'];
-				const lastName = contact['properties']['lastname']['value'];
-                const email = identities[0]['value'];
-				//URL should be built using express URL class
-				const postParticipant = 'https://staging.referralsaasquatch.com/api/v1/' +STENANTALIAS+ '/open/account/' + email + '/user/' + email;
-				//console.log(postParticipant);
-				
-				const response = await axios.post(postParticipant,{
-
-
-						id: firstName+lastName,
-						accountId: firstName+lastName,
-						firstName: firstName,
-						lastInitial: lastName[0],
-						email: email,
-						lastName: lastName,
-
-					},
-					{
-					  headers: {
-				        'Authorization':'token '+SAPIKEY
-				    }
-					});
-
-			}
-		}
-
-        return;
-    } catch (e) {
-        console.log(e);
-        return e;
+    //console.log('EMAIL:' + contact['identity-profiles'][0]['identities'][0]['value']);
+    const identities = contact['identity-profiles'][0]['identities'];
+    if (identities) {
+        if (isHubspotEmail(identities[0])) {
+            //can be just dot mo [']
+            const firstName = contact['properties']['firstname']['value'];
+            const lastName = contact['properties']['lastname']['value'];
+            const email = identities[0]['value'];
+            //URL should be built using express URL class
+            const postParticipant =
+                'https://staging.referralsaasquatch.com/api/v1/' +
+                STENANTALIAS +
+                '/open/account/' +
+                email +
+                '/user/' +
+                email;
+            try {
+                const response = await axios.post(
+                    postParticipant,
+                    {
+                        id: firstName + lastName,
+                        accountId: firstName + lastName,
+                        firstName: firstName,
+                        lastInitial: lastName[0],
+                        email: email,
+                        lastName: lastName,
+                    },
+                    {
+                        headers: {
+                            Authorization: 'token ' + SAPIKEY,
+                        },
+                    },
+                );
+                return response;
+            } catch (e) {
+                console.error(e);
+            }
+        }
     }
-
-
 }
 
 // queries the list of users for the account with the given API key and returns the list
@@ -109,131 +101,107 @@ async function postContacts(contact: any) {
 //	- move the postContacts funtion to its own route
 
 const getContacts = async () => {
+    //console.log('=== attempting to get all hubpsot conacts api key is ===' + HAPIKEY);
+    const allContacts = 'https://api.hubapi.com/contacts/v1/lists/all/contacts/all?hapikey=' + HAPIKEY;
     try {
-        console.log('=== attempting to get all hubpsot conacts api key is ===' + HAPIKEY);
-        const allContacts = 'https://api.hubapi.com/contacts/v1/lists/all/contacts/all?hapikey=' + HAPIKEY;
         const response = await axios.get(allContacts);
         const data = response.data;
-		//console.log(data);
-		//isolates just the contacts portion of the response
-		let hubspotContacts = data['contacts'] || [];
-		//console.log(hubspotContacts);
-
-		if(hubspotContacts.length !== 0){
-			await hubspotContacts.forEach(postContacts);
-		}
+        //isolates just the contacts portion of the response
+        const hubspotContacts = data['contacts'] || [];
+        if (hubspotContacts.length !== 0) {
+            try {
+                await hubspotContacts.forEach(postContacts);
+            } catch (e) {
+                console.error('  > Failed in posting contacts from HubSpot to SaaSquatch');
+                console.error(e);
+            }
+        }
         return data;
     } catch (e) {
-        console.error('  > Unable to retrieve contact');
-
-        return JSON.parse(e.response.body);
+        console.error('  > Unable to retrieve all contacts form HubSpot');
+        console.error(e);
     }
-
-
-}
+};
 
 router.get('/contacts', async (req, res) => {
-
-    try
-    {
+    try {
         //#todo: Update line below to get refresh_token from db when its ready
-        const contact = await HubApiCall(getContacts,tokenStore[req.sessionID]["refresh_token"]);//await getContacts();
+        const contact = await HubApiCall(getContacts, tokenStore[req.sessionID]['refresh_token']); //await getContacts();
         res.json(contact);
-        console.log('got contacts');
         res.end();
-
-    }
-    catch(e)
-    {
-        res.redirect("/hubspot");
+    } catch (e) {
+        console.error(e);
+        res.redirect('/hubspot');
     }
 });
 
 router.post('/contacts', async (req, res) => {
-
     const contact = await getContacts();
     res.json(contact);
-    console.log('got contacts');
     res.end();
 });
 
-
 // add the participants in Saas to Hubspot contact list
-async function addContacts(participant:any)  {
+async function addContacts(participant: any) {
     try {
-        console.log('=== attempting to get all hubpsot conacts api key is ===' + HAPIKEY);
         const addContact = 'https://api.hubapi.com/crm/v3/objects/contacts?hapikey=' + HAPIKEY;
-        const response = await axios.post(addContact,{
+        const response = await axios.post(addContact, {
             properties: {
                 company: '',
                 email: participant.email,
                 firstname: participant.firstName,
                 lastname: participant.lastName,
                 phone: '',
-                website: ''
+                website: '',
             },
         });
-
-
         return response;
     } catch (e) {
         console.error('  > Unable to add new contact');
-        return JSON.parse(e.response.body);
     }
 }
 
 //returns a list of Saasquatch participants for a given api key and tenet alias
 const getParticipants = async () => {
     try {
-        console.log('=== attempting to get all SaaSquatch participants api key is ===' + SAPIKEY);
-        const allParticipants = 'https://staging.referralsaasquatch.com/api/v1/' +STENANTALIAS+ '/users';
-        console.log(allParticipants);
+        //console.log('=== attempting to get all SaaSquatch participants api key is ===' + SAPIKEY);
+        const allParticipants = 'https://staging.referralsaasquatch.com/api/v1/' + STENANTALIAS + '/users';
         const response = await axios.get(allParticipants, {
             auth: {
                 username: '',
-                password: SAPIKEY
-            }
+                password: SAPIKEY,
+            },
         });
-        console.log('test' + response);
         const data = response.data;
-        //console.log(data);
-        if (data.count != 0 ){
-            console.log('there are total '+  data.count + " contacts");
-            for(let i=0; i<data.count; i++){
-                console.log(data.users[i].id);
+        if (data.count != 0) {
+            //console.log('there are total ' + data.count + ' contacts');
+            for (let i = 0; i < data.count; i++) {
+                //console.log(data.users[i].id);
                 addContacts(data.users[i]);
             }
         }
         return data;
     } catch (e) {
         console.error('  > Unable to retrieve participants');
-        console.log(e);
-        return e;
+        console.error(e);
     }
-
-
-}
+};
 
 router.get('/participants', async (req, res) => {
-    try{
-    const Participants = await getParticipants();
-    console.log('res:' + res)
-    res.json(Participants);
-    console.log('got Participants');
-    res.end();
-    } 
-    catch (e) {
-        //  As per Muhammads request: 
-        //  user disconnects our integration and access 
-        //  token has expired so the API calls will return 
-        //  an error. In this scenario We must redirect user 
-        //  to authorize the application again. So in the catch 
+    try {
+        const Participants = await getParticipants();
+        res.json(Participants);
+        res.end();
+    } catch (e) {
+        //  As per Muhammads request:
+        //  user disconnects our integration and access
+        //  token has expired so the API calls will return
+        //  an error. In this scenario We must redirect user
+        //  to authorize the application again. So in the catch
         //  we can have res.redirect("/hubspot"))
-    console.error('  > Unable to retrieve participants');
-    console.log(e);
-    return e;
-}
-
+        console.error('  > Unable to retrieve participants');
+        console.error(e);
+    }
 });
 
-export default router
+export default router;

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -2,24 +2,31 @@ import { Router } from 'express';
 require('dotenv').config();
 import axios from 'axios';
 const querystring = require('query-string');
-import {AddTokensToDatabase} from "../database"
-import {PollTokensFromDatabase} from "../database";
-import {hubspotUpdatesController} from "../integration/hubspotUpdatesController";
+import { AddTokensToDatabase } from '../database';
+import { PollTokensFromDatabase } from '../database';
+import { IntegrationTokens } from '../Types/types';
 const jwt = require('jsonwebtoken');
 
-
 const router = Router();
- let hubspotID:string;
+let hubspotID: string;
 
 const HUBSPOT_CLIENT_ID = process.env.HUBSPOT_CLIENT_ID;
 const HUBSPOT_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET;
 const HUBSPOT_REDIRECT_URI = process.env.HUBSPOT_REDIRECT_URI;
 
 let HUBSPOT_AUTH_URL: string;
-if(HUBSPOT_CLIENT_ID && HUBSPOT_REDIRECT_URI){
-    HUBSPOT_AUTH_URL = `https://app.hubspot.com/oauth/authorize?client_id=${encodeURIComponent(HUBSPOT_CLIENT_ID)}&redirect_uri=${encodeURIComponent(HUBSPOT_REDIRECT_URI)}&scope=contacts`;
-}else{
-    console.error("HUBSPOT_CLIENT_ID:"+HUBSPOT_CLIENT_ID+" or HUBSPOT_REDIRECT_URI:"+HUBSPOT_REDIRECT_URI+" not defined in environment variables.");
+if (HUBSPOT_CLIENT_ID && HUBSPOT_REDIRECT_URI) {
+    HUBSPOT_AUTH_URL = `https://app.hubspot.com/oauth/authorize?client_id=${encodeURIComponent(
+        HUBSPOT_CLIENT_ID,
+    )}&redirect_uri=${encodeURIComponent(HUBSPOT_REDIRECT_URI)}&scope=contacts`;
+} else {
+    console.error(
+        'HUBSPOT_CLIENT_ID:' +
+            HUBSPOT_CLIENT_ID +
+            ' or HUBSPOT_REDIRECT_URI:' +
+            HUBSPOT_REDIRECT_URI +
+            ' not defined in environment variables.',
+    );
 }
 
 // Saasquatch
@@ -30,73 +37,78 @@ export const tokenStore: any = {};
 
 // Generate Server Access Token for frontend requests
 const generateAccessToken = (userID: string) => {
-	return jwt.sign({
-		data: userID
-	}, process.env.SERVER_TOKEN_SECRET, { expiresIn: '1h' });
-}
+    return jwt.sign(
+        {
+            data: userID,
+        },
+        process.env.SERVER_TOKEN_SECRET,
+        { expiresIn: '1h' },
+    );
+};
 
 // Authenticate Server Access Token for frontend requests
-export const authenticateToken = (token: string) => {
-	try {
-		const decoded = jwt.verify(token, process.env.SERVER_TOKEN_SECRET);
-		return decoded;
-	}
-	catch (err) { console.log(err.message); }
+export const authenticateToken = (token: string): any => {
+    try {
+        const decoded = jwt.verify(token, process.env.SERVER_TOKEN_SECRET);
+        return decoded;
+    } catch (err) {
+        console.error(err.message);
+    }
 };
 
 /**
  * Gets a new access token from Hubspot
- * 
+ *
  * @param refreshToken Hubspot refresh token
  * @returns Hubspot access token object.
  */
-export const getHubspotAccessToken = async (refreshToken: string | undefined) => {
-	if (!refreshToken) {
-		throw new Error(`Refresh token not provided to getHubspotAccessToken.`);
-	} else if (!HUBSPOT_CLIENT_ID) {
-		throw new Error(`No Hubspot Client ID.`);
-	} else if (!HUBSPOT_CLIENT_SECRET) {
-		throw new Error(`No Hubspot Client Secret.`);
-	}
-	try {
-		const url = 'https://api.hubapi.com/oauth/v1/token';
+export const getHubspotAccessToken = async (refreshToken: string | undefined): Promise<any> => {
+    if (!refreshToken) {
+        throw new Error(`Refresh token not provided to getHubspotAccessToken.`);
+    } else if (!HUBSPOT_CLIENT_ID) {
+        throw new Error(`No Hubspot Client ID.`);
+    } else if (!HUBSPOT_CLIENT_SECRET) {
+        throw new Error(`No Hubspot Client Secret.`);
+    }
+    try {
+        const url = 'https://api.hubapi.com/oauth/v1/token';
         const refreshTokenProof = {
             grant_type: 'refresh_token',
             client_id: HUBSPOT_CLIENT_ID,
             client_secret: HUBSPOT_CLIENT_SECRET,
             refresh_token: refreshToken,
         };
-		const resp = await axios.post(url, querystring.stringify(refreshTokenProof));
-		return resp.data;
-	} catch(e) {
-		throw new Error(e);
-	}
-}
+        const resp = await axios.post(url, querystring.stringify(refreshTokenProof));
+        return resp.data;
+    } catch (e) {
+        throw new Error(e);
+    }
+};
 
 /**
  * Gets a new API JWT from Saasquatch
- * 
+ *
  * @returns Saasquatch JWT object.
  */
-export const getSaasquatchToken = async () =>  {
-	if (!SAASQUATCH_CLIENT_ID) {
-		throw new Error(`No Saasquatch Client ID.`);
-	} else if (!SAASQUATCH_CLIENT_SECRET) {
-		throw new Error(`No Saasquatch Client Secret.`);
-	}
-	try {
-		const url = "https://squatch-dev.auth0.com/oauth/token";
-		const tokenProof = {
-			"grant_type": "client_credentials",
-			"client_id": SAASQUATCH_CLIENT_ID,
-			"client_secret": SAASQUATCH_CLIENT_SECRET,
-			"audience": "https://staging.referralsaasquatch.com"
-		};
-		const resp = await axios.post(url, querystring.stringify(tokenProof));
-		return resp.data;
-	} catch(e) {
-		throw new Error(e);
-	}
+export const getSaasquatchToken = async (): Promise<any> => {
+    if (!SAASQUATCH_CLIENT_ID) {
+        throw new Error(`No Saasquatch Client ID.`);
+    } else if (!SAASQUATCH_CLIENT_SECRET) {
+        throw new Error(`No Saasquatch Client Secret.`);
+    }
+    try {
+        const url = 'https://squatch-dev.auth0.com/oauth/token';
+        const tokenProof = {
+            grant_type: 'client_credentials',
+            client_id: SAASQUATCH_CLIENT_ID,
+            client_secret: SAASQUATCH_CLIENT_SECRET,
+            audience: 'https://staging.referralsaasquatch.com',
+        };
+        const resp = await axios.post(url, querystring.stringify(tokenProof));
+        return resp.data;
+    } catch (e) {
+        throw new Error(e);
+    }
 };
 
 // Start HubSpot OAuth flow
@@ -108,85 +120,86 @@ router.get('/hubspot_authorization', async (req, res) => {
 	}
     if(decoded != undefined) {
         try {
-			res.json("Authorized");
-			res.end();
-        }
-        catch(e){
+            res.json('Authorized');
+            res.end();
+        } catch (e) {
             console.error(e);
         }
-    } else{
-        if(HUBSPOT_AUTH_URL){
-			res.json("Unauthorized");
-			res.end();
-        }else{
-            console.error("env AUTH_URL is undefined.");
+    } else {
+        if (HUBSPOT_AUTH_URL) {
+            res.json('Unauthorized');
+            res.end();
+        } else {
+            console.error('env AUTH_URL is undefined.');
         }
     }
 });
 
 // 2. Get Hubspot OAuth URL if the user has not authenticated
 router.get('/hubspot_url', async (req, res) => {
-	if(HUBSPOT_AUTH_URL){
-		res.json(HUBSPOT_AUTH_URL);
-		res.end();
-	}else{
-		console.error("env AUTH_URL is undefined.");
-	}
+    if (HUBSPOT_AUTH_URL) {
+        res.json(HUBSPOT_AUTH_URL);
+        res.end();
+    } else {
+        console.error('env AUTH_URL is undefined.');
+    }
 });
 
 // 3. Get temporary authorization code from OAuth server
 // 4. Combine temporary auth code with app credentials and send back to OAuth server
 router.get('/oauth-callback', async (req, res) => {
     // If temp authorization code was received
-    if(req.query.code){
+    if (req.query.code) {
         const code: any = req.query.code;
         const authCodeProof = {
             grant_type: 'authorization_code',
             client_id: HUBSPOT_CLIENT_ID,
             client_secret: HUBSPOT_CLIENT_SECRET,
             redirect_uri: HUBSPOT_REDIRECT_URI,
-            code: code
+            code: code,
         };
         try {
             // 4.Get access and refresh tokens
-            const resp = await axios.post('https://api.hubapi.com/oauth/v1/token', querystring.stringify(authCodeProof));
-            if (resp.status != 200)
-            {
-                throw Error("POST to get access and refresh tokens from HubSpot failed. Error:" + resp.data["error"]);
+            const resp = await axios.post(
+                'https://api.hubapi.com/oauth/v1/token',
+                querystring.stringify(authCodeProof),
+            );
+            if (resp.status != 200) {
+                throw Error('POST to get access and refresh tokens from HubSpot failed. Error:' + resp.data['error']);
             }
-			// this api call is to retrieve the user id of the current user
-			// the post api call above does not contain user_id
-			const get_options = {
-				headers: {accept: 'application/json'}
-			};
-            const get_user_id = await axios.get('https://api.hubapi.com/oauth/v1/refresh-tokens/'+resp.data.refresh_token,get_options);
-			//#todo temporarily using user email for tenant alias rather than id
-			// as the db does not support number tenant alias currently
-			hubspotID = get_user_id.data.user;
-			// #todo in a seperate ticket check first whether the user already exists in DB
-            AddTokensToDatabase(hubspotID, resp.data.access_token, resp.data.refresh_token)
-			// store user id in local tokenStore for knowledge of current user
-			// and for knowing which user to poll the DB
-            tokenStore["userID"] = hubspotID;
-			
-			res.redirect('/hubspot?hubspotID=' +hubspotID);
-        }
-        catch(e)
-		{
+            // this api call is to retrieve the user id of the current user
+            // the post api call above does not contain user_id
+            const get_options = {
+                headers: { accept: 'application/json' },
+            };
+            const get_user_id = await axios.get(
+                'https://api.hubapi.com/oauth/v1/refresh-tokens/' + resp.data.refresh_token,
+                get_options,
+            );
+            //#todo temporarily using user email for tenant alias rather than id
+            // as the db does not support number tenant alias currently
+            hubspotID = get_user_id.data.user;
+            // #todo in a seperate ticket check first whether the user already exists in DB
+            AddTokensToDatabase(hubspotID, resp.data.access_token, resp.data.refresh_token);
+            // store user id in local tokenStore for knowledge of current user
+            // and for knowing which user to poll the DB
+            tokenStore['userID'] = hubspotID;
+
+            res.redirect('/hubspot?hubspotID=' + hubspotID);
+        } catch (e) {
             console.error(e);
         }
     }
     // Log error if no code received
-    else
-    	{
-        console.error("HubSpot OAuth callback did not receive temp access code.");
-    	}
+    else {
+        console.error('HubSpot OAuth callback did not receive temp access code.');
+    }
 });
 
 // 5. Send user to authorization page if unsuccessful or create access token and close popup
 router.get('/hubspot', async (req, res) => {
-	const hubspotID = req.query.hubspotID;
-    if(hubspotID) {
+    const hubspotID = req.query.hubspotID;
+    if (hubspotID) {
         try {
 			const frontendToken = generateAccessToken(hubspotID as string);
 			res.status(200).send(`<script>document.cookie="frontendToken=${frontendToken}; SameSite=None; Secure"; window.close();</script>`);
@@ -194,89 +207,75 @@ router.get('/hubspot', async (req, res) => {
         catch(e){
             console.error(e);
         }
-    } else{
+    } else {
         // If not authorized, send to auth url
-        if(HUBSPOT_AUTH_URL){
-			res.redirect(HUBSPOT_AUTH_URL);
-        }else{
-            console.error("env AUTH_URL is undefined.");
+        if (HUBSPOT_AUTH_URL) {
+            res.redirect(HUBSPOT_AUTH_URL);
+        } else {
+            console.error('env AUTH_URL is undefined.');
         }
     }
 });
 
 // Test route, delete later
-router.get("/saasquatch_token", async (req, res) => {
-	try {
-		const token = await getSaasquatchToken();
-		res.send(token);
-	} catch(e) {
-		console.log(e);
-		res.send(e);
-	}
+router.get('/saasquatch_token', async (req, res) => {
+    try {
+        const token = await getSaasquatchToken();
+        res.send(token);
+    } catch (e) {
+        console.error(e);
+        res.send(e);
+    }
 });
 
 // Test route, delete later
-router.get("/hubspot_refresh_token", async (req, res) => {
-	try {
-		let tokens = await PollTokensFromDatabase(hubspotID);
-		console.log(tokens)
-		const token = await getHubspotAccessToken(tokens.refreshToken);
-		res.send(token);
-	} catch(e) {
-		console.log(e);
-		res.send(e);
-	}
+router.get('/hubspot_refresh_token', async (req, res) => {
+    try {
+        const tokens: IntegrationTokens = await PollTokensFromDatabase(hubspotID);
+        const token = await getHubspotAccessToken(tokens.refreshToken);
+        res.send(token);
+    } catch (e) {
+        console.error(e);
+        res.send(e);
+    }
 });
 
-
-export const HubApiCall:any = async function (myapifunc:Function,refresh_token:string)
-{
-	// first try to see if the api call goes through if it does then send response back
-	try
-	{
-		let result = await myapifunc()
-		// api call went through everything is fine
-		return result;
-	}
-	catch(e)
-	{
-		try
-		{
-			//error in the api call get a new access token
-			let result = await getHubspotAccessToken(refresh_token);
-			if(result.status ==400)//result.response.status == 400)
-			{
-				if(process.env.NODE_ENV == 'test')
-				{
-					// return error result for the testing purpose
-					return result;
-				}
-				else
-				{
-				//below is equivalent to rejecting promise return Promise.reject(400 /*or Error*/ );
-					return JSON.parse(result);
-				}
-			}
-			else
-				// there was no error so we can store the result.
-			{
-				// #todo: Update the line below configure with DB
-				tokenStore[hubspotID] = {"access_token": result};
-				return await HubApiCall(myapifunc,refresh_token);
-				// over here we probably want to call the ApiCall again with the same arguments
-				// or we want to redirect to the url we were called from
-			}
-		}
-		catch(e)
-		{
-			//something went wrong?
-			return Promise.reject(400 /*or Error*/ );
-		}
-	}
-}
-export function get_current_user()
-{
-	return hubspotID;
+export const HubApiCall = async function (myapifunc: () => Promise<any>, refresh_token: string): Promise<any> {
+    // first try to see if the api call goes through if it does then send response back
+    try {
+        const result = await myapifunc();
+        // api call went through everything is fine
+        return result;
+    } catch (e) {
+        try {
+            //error in the api call get a new access token
+            const result = await getHubspotAccessToken(refresh_token);
+            if (result.status == 400) {
+                //result.response.status == 400)
+                if (process.env.NODE_ENV == 'test') {
+                    // return error result for the testing purpose
+                    return result;
+                } else {
+                    //below is equivalent to rejecting promise return Promise.reject(400 /*or Error*/ );
+                    return JSON.parse(result);
+                }
+            }
+            // there was no error so we can store the result.
+            else {
+                // #todo: Update the line below configure with DB
+                tokenStore[hubspotID] = { access_token: result };
+                return await HubApiCall(myapifunc, refresh_token);
+                // over here we probably want to call the ApiCall again with the same arguments
+                // or we want to redirect to the url we were called from
+            }
+        } catch (e) {
+            //something went wrong?
+            return Promise.reject(400 /*or Error*/);
+        }
+    }
+};
+export function get_current_user(): string {
+    return hubspotID;
 }
 
-export default router
+export default router;

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -114,11 +114,11 @@ export const getSaasquatchToken = async (): Promise<any> => {
 // Start HubSpot OAuth flow
 // 1. Check whether user has previously authenticated with Hubspot and received a token
 router.get('/hubspot_authorization', async (req, res) => {
-	let decoded = undefined
-	if(req.cookies.frontendToken) {
-		decoded = authenticateToken(req.cookies.frontendToken as string)
-	}
-    if(decoded != undefined) {
+    let decoded = undefined;
+    if (req.cookies.frontendToken) {
+        decoded = authenticateToken(req.cookies.frontendToken as string);
+    }
+    if (decoded != undefined) {
         try {
             res.json('Authorized');
             res.end();
@@ -201,10 +201,11 @@ router.get('/hubspot', async (req, res) => {
     const hubspotID = req.query.hubspotID;
     if (hubspotID) {
         try {
-			const frontendToken = generateAccessToken(hubspotID as string);
-			res.status(200).send(`<script>document.cookie="frontendToken=${frontendToken}; SameSite=None; Secure"; window.close();</script>`);
-        }
-        catch(e){
+            const frontendToken = generateAccessToken(hubspotID as string);
+            res.status(200).send(
+                `<script>document.cookie="frontendToken=${frontendToken}; SameSite=None; Secure"; window.close();</script>`,
+            );
+        } catch (e) {
             console.error(e);
         }
     } else {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,16 +1,14 @@
-import {PollTokensFromDatabase} from "../database";
 require('dotenv').config();
 import { Router } from 'express';
-import * as jwt from "jsonwebtoken";
-import jwksRsa = require("jwks-rsa");
-import { Base64 } from "js-base64";
+import * as jwt from 'jsonwebtoken';
+import jwksRsa = require('jwks-rsa');
+import { Base64 } from 'js-base64';
 import { SubscriptionType, HubspotPayload, SaasquatchPayload, EventType, Configuration } from '../Types/types';
 import saasquatchSchema from '../Types/saasquatch-payload-schema.json';
 import hubspotSchema from '../Types/hubspot-payload-schema.json';
-import Ajv from "ajv";
+import Ajv from 'ajv';
 import { hubspotUpdatesController } from '../integration/hubspotUpdatesController';
 import { saasquatchUpdatesController } from '../integration/saasquatchUpdatesController';
-
 import { MOCK_SESSION_USER_ID } from '../mock';
 import { ConfigurationModel } from '../integration/ConfigurationModel';
 
@@ -26,96 +24,99 @@ const HUBSPOT_WEBHOOK_URI = process.env.HUBSPOT_WEBHOOK_URI;
 const SAASQUATCH_JWKS_URI = process.env.SAASQUATCH_JWKS_URI;
 
 let saasquatchJwksClient: jwksRsa.JwksClient;
-if(SAASQUATCH_JWKS_URI){
+if (SAASQUATCH_JWKS_URI) {
     saasquatchJwksClient = jwksRsa({
         jwksUri: SAASQUATCH_JWKS_URI,
         cache: false,
     });
-}else{
-    console.error("SAASQUATCH_JWKS_URI is not defined in environment variables and is required for SaaSquatch Webhooks.\
-     For staging this should be https://staging.referralsaasquatch.com/.well-known/jwks.json.");
+} else {
+    console.error(
+        'SAASQUATCH_JWKS_URI is not defined in environment variables and is required for SaaSquatch Webhooks.\
+     For staging this should be https://staging.referralsaasquatch.com/.well-known/jwks.json.',
+    );
 }
 // Replace with access token from OAuth when DB set up
 // # todo: the saasquatch controller appears to use the HAPI key will need to verify
 // # todo: whether that can be replaced with hub access token
 if (!process.env.HAPIKEY || !process.env.SAPIKEY || !process.env.STENANTALIAS) {
-    throw new Error('Missing environment variable.')
+    throw new Error('Missing environment variable.');
 }
 
 // JSON schema validator
 const ajv: any = new Ajv();
-ajv.addSchema(hubspotSchema, "hubspot");
-ajv.addSchema(saasquatchSchema, "saasquatch");
+ajv.addSchema(hubspotSchema, 'hubspot');
+ajv.addSchema(saasquatchSchema, 'saasquatch');
 
-const validateHubspotSchema = ajv.getSchema("hubspot");
-const validateSaasquatchSchema = ajv.getSchema("saasquatch");
-
+const validateHubspotSchema = ajv.getSchema('hubspot');
+const validateSaasquatchSchema = ajv.getSchema('saasquatch');
 
 const hubUpdatesController = new hubspotUpdatesController(process.env.SAPIKEY, process.env.STENANTALIAS);
 
-const saasUpdatesController = new saasquatchUpdatesController(process.env.HAPIKEY, process.env.SAPIKEY, process.env.STENANTALIAS);
+const saasUpdatesController = new saasquatchUpdatesController(
+    process.env.HAPIKEY,
+    process.env.SAPIKEY,
+    process.env.STENANTALIAS,
+);
 
-const crypto = require("crypto");
+const crypto = require('crypto');
 
 /**
  * Endpoint for webhooks from SaaSquatch
- */ 
-router.post("/saasquatch-webhook", async (req, res) => {
-    const jwsNoPayloadHeader: string | undefined = req.get("X-Hook-JWS-RFC-7797");
-    if (!jwsNoPayloadHeader){
+ */
+router.post('/saasquatch-webhook', async (req, res) => {
+    const jwsNoPayloadHeader: string | undefined = req.get('X-Hook-JWS-RFC-7797');
+    if (!jwsNoPayloadHeader) {
         res.status(401).end();
         return;
     }
     // Verify request came from SaaSquatch
     validateSaaSquatchWebhook(JSON.stringify(req.body), jwsNoPayloadHeader)
-    .then(decoded =>{
-        // Validate JSON format with schema
-        // Note: this does not validate fields or format within the 'data' object as this varies greatly between webhooks.
-        if(!validateSaasquatchSchema(decoded)){
-            console.error("Request body is invalid in format and does not match expected SaaSquatch schema");
-            console.error("Failed at "+ validateSaasquatchSchema.errors);
-            res.status(400).end();
-            return;
-        }
-        res.status(200).end();
+        .then((decoded) => {
+            // Validate JSON format with schema
+            // Note: this does not validate fields or format within the 'data' object as this varies greatly between webhooks.
+            if (!validateSaasquatchSchema(decoded)) {
+                console.error('Request body is invalid in format and does not match expected SaaSquatch schema');
+                console.error('Failed at ' + validateSaasquatchSchema.errors);
+                res.status(400).end();
+                return;
+            }
+            res.status(200).end();
 
-        // Map to interface
-        const saasquatchPayload = decoded as SaasquatchPayload;
-        //console.log(saasquatchPayload);
+            // Map to interface
+            const saasquatchPayload = decoded as SaasquatchPayload;
+            //console.log(saasquatchPayload);
 
-        processSaasquatchPayload(saasquatchPayload);
-
-    })
-    .catch(error => {
-        console.warn("Received invalid SaaSquatch Webhook.")
-        console.error(error);
-        res.status(500).end();
-    });
-    
+            processSaasquatchPayload(saasquatchPayload);
+        })
+        .catch((error) => {
+            console.warn('Received invalid SaaSquatch Webhook.');
+            console.error(error);
+            res.status(500).end();
+        });
 });
 
 /**
  * Endpoint for webhooks from HubSpot
  */
-router.post("/hubspot-webhook", async (req, res) => {
-    const signatureVersion = req.get("X-HubSpot-Signature-Version");
-    const signature = req.get("X-HubSpot-Signature");
-    if (!(signatureVersion && signature)){
+router.post('/hubspot-webhook', async (req, res) => {
+    const signatureVersion = req.get('X-HubSpot-Signature-Version');
+    const signature = req.get('X-HubSpot-Signature');
+    if (!(signatureVersion && signature)) {
         res.status(401).end();
         return;
     }
     // Verify request came from HubSpot
     const isValid: boolean = validateHubSpotWebhook(signatureVersion, signature, JSON.stringify(req.body));
-    if (!isValid){
-        console.warn("Received invalid HubSpot Webhook.")
+    if (!isValid) {
+        console.warn('Received invalid HubSpot Webhook.');
         res.status(401).end();
         return;
     }
     // Validate JSON format with schema
-    if(!validateHubspotSchema(req.body)){
-        console.error("Request body is invalid in format and does not match expected HubSpot schema.");
-        console.error("Failed at: ");
-		console.error(validateHubspotSchema.errors);
+    if (!validateHubspotSchema(req.body)) {
+        console.error('Request body is invalid in format and does not match expected HubSpot schema.');
+        console.error('Failed at: ');
+        console.error(validateHubspotSchema.errors);
         res.status(400).end();
         return;
     }
@@ -123,111 +124,106 @@ router.post("/hubspot-webhook", async (req, res) => {
     //console.log(req.body);
 
     // Sort payload by time occured. ie. contact creation should come before contact property change
-    req.body.sort((a: HubspotPayload, b: HubspotPayload) => a.occurredAt < b.occurredAt ? -1 : 1 );
+    req.body.sort((a: HubspotPayload, b: HubspotPayload) => (a.occurredAt < b.occurredAt ? -1 : 1));
     // Map each object to interface and process subscription type
-    req.body.forEach( (hubspotPayload: HubspotPayload) => {
+    req.body.forEach((hubspotPayload: HubspotPayload) => {
         processHubspotPayload(hubspotPayload);
     });
-    
 });
 
 async function processSaasquatchPayload(saasquatchPayload: SaasquatchPayload) {
-	//  TODO: Change to use information from webhook
-	const userIdentifier: string = MOCK_SESSION_USER_ID
-	const configuration: Configuration = await ConfigurationModel.getConfiguration(userIdentifier)
-	if(configuration.PushPartixipantsAsContacts) 
-		switch(saasquatchPayload.type){
-			case EventType.UserCreated:
-				saasUpdatesController.NewUser(saasquatchPayload);
-				break;
-			case EventType.Test:
-				saasUpdatesController.Test(saasquatchPayload);
-				break;
-			default:
-				console.error("No matching EventType. May not yet be implemented.\
-				Received type: "+saasquatchPayload.type);
-		}
-	else console.log(`Ignored SaaSquatch WebHook:\t${saasquatchPayload.type}`)
+    //  TODO: Change to use information from webhook
+    const userIdentifier: string = MOCK_SESSION_USER_ID;
+    const configuration: Configuration = await ConfigurationModel.getConfiguration(userIdentifier);
+    if (configuration.PushPartixipantsAsContacts)
+        switch (saasquatchPayload.type) {
+            case EventType.UserCreated:
+                saasUpdatesController.NewUser(saasquatchPayload);
+                break;
+            case EventType.Test:
+                saasUpdatesController.Test(saasquatchPayload);
+                break;
+            default:
+                console.error(
+                    'No matching EventType. May not yet be implemented.\
+				Received type: ' + saasquatchPayload.type,
+                );
+        }
+    else console.warn(`Ignored SaaSquatch WebHook:\t${saasquatchPayload.type}`);
 }
-
 
 async function processHubspotPayload(hubspotPayload: HubspotPayload) {
-	const userIdentifier: string = MOCK_SESSION_USER_ID
-	const configuration: Configuration = await ConfigurationModel.getConfiguration(userIdentifier)
-	console.log(`Recieved Hubspot Webhook:\t${hubspotPayload.eventId}`)
-	if(configuration.PushContactsAsParticipants)
-		switch (hubspotPayload.subscriptionType){
-			case SubscriptionType.ContactCreation:
-				hubUpdatesController.NewContact(hubspotPayload);
-				break;
-			case SubscriptionType.ContactDeletion:
-				hubUpdatesController.DeletedContact(hubspotPayload);
-				break;
-			case SubscriptionType.ContactPropertyChange:
-				hubUpdatesController.ChangedContact(hubspotPayload);
-				break;
-			default:
-				console.error("No matching subscriptionType. May not yet be implemented.\
-				Received subscriptionType: "+hubspotPayload.subscriptionType);
-		}
-	else console.log(`Ignored HubSpot WebHook:\t${hubspotPayload.subscriptionType}`)
+    const userIdentifier: string = MOCK_SESSION_USER_ID;
+    const configuration: Configuration = await ConfigurationModel.getConfiguration(userIdentifier);
+    if (configuration.PushContactsAsParticipants)
+        switch (hubspotPayload.subscriptionType) {
+            case SubscriptionType.ContactCreation:
+                hubUpdatesController.NewContact(hubspotPayload);
+                break;
+            case SubscriptionType.ContactDeletion:
+                hubUpdatesController.DeletedContact(hubspotPayload);
+                break;
+            case SubscriptionType.ContactPropertyChange:
+                hubUpdatesController.ChangedContact(hubspotPayload);
+                break;
+            default:
+                console.error(
+                    'No matching subscriptionType. May not yet be implemented.\
+				Received subscriptionType: ' +
+                        hubspotPayload.subscriptionType,
+                );
+        }
+    else console.warn(`Ignored HubSpot WebHook:\t${hubspotPayload.subscriptionType}`);
 }
-
-
-
-
 
 /**
  * Validate the given JWT with SaaSquatch public JWKS and get the claims.
- * 
+ *
  * @param token The input JWT
  */
-export function validateWithSaaSquatchJwks(token: string): Promise<object> {
+export function validateWithSaaSquatchJwks(token: string): Promise<any> {
     return new Promise((resolve, reject) => {
         jwt.verify(
-        token,
-        (header, callback) => {
-            saasquatchJwksClient.getSigningKey(header.kid, (err, key) => {
-                callback(err, key ? key.getPublicKey() : undefined);
-            });
-        },
-        (err, decoded) => {
-            if (err) {
-                reject(err);
-            } else if (decoded){
-                resolve(decoded);
-            }
-        }
-    )});
+            token,
+            (header, callback) => {
+                saasquatchJwksClient.getSigningKey(header.kid, (err, key) => {
+                    callback(err, key ? key.getPublicKey() : undefined);
+                });
+            },
+            (err, decoded) => {
+                if (err) {
+                    reject(err);
+                } else if (decoded) {
+                    resolve(decoded);
+                }
+            },
+        );
+    });
 }
 
 /**
- * Verifying a SaaSquatch Webhook Payload: 
+ * Verifying a SaaSquatch Webhook Payload:
  * 1. Ensure the X-Hook-JWS-RFC-7797 header exists. If it doesn't exist, this request didn't come from SaaSquatch.
- * 2. Look up the SaaSquatch JWKS at http://app.referralsaasquatch.com/.well-known/jwks.json. This contains the 
- *    public keys, and should have a kid that matches the JWS Header of the JWS. The JWKS changes regularly and 
- *    should not be cached in its entirety. 
+ * 2. Look up the SaaSquatch JWKS at http://app.referralsaasquatch.com/.well-known/jwks.json. This contains the
+ *    public keys, and should have a kid that matches the JWS Header of the JWS. The JWKS changes regularly and
+ *    should not be cached in its entirety.
  * 3. Grab the JSON body from the request. This should always be JSON.
  * 4. Use a JWT library to verify the body matches the signature.
- * 
+ *
  * REF: https://docs.saasquatch.com/api/webhooks/security/
  *
  * @param webhookBody The raw text of the webhook body.
  * @param jwsNoPayloadHeader The value of the X-Hook-JWS-RFC-7797 header.
  */
-export function validateSaaSquatchWebhook(
-    webhookBody: string,
-    jwsNoPayloadHeader: string
-): Promise<object> {
-    const webhookBodyBase64 = Base64.encodeURI(webhookBody);
-    const token = jwsNoPayloadHeader.replace("..", "." + webhookBodyBase64 + ".");
+export function validateSaaSquatchWebhook(webhookBody: string, jwsNoPayloadHeader: string): Promise<any> {
+    const webhookBodyBase64: string = Base64.encodeURI(webhookBody);
+    const token = jwsNoPayloadHeader.replace('..', '.' + webhookBodyBase64 + '.');
     return validateWithSaaSquatchJwks(token);
 }
 
-
 /**
- *  Verifying a HubSpot Webhook Payload: 
- * 1. Check the X-HubSpot-Signature and X-HubSpot-Signature-Version headers exists. If these don't, this request 
+ *  Verifying a HubSpot Webhook Payload:
+ * 1. Check the X-HubSpot-Signature and X-HubSpot-Signature-Version headers exists. If these don't, this request
  *    didn't come from HubSpot.
  * 2. Check the X-HubSpot-Signature-Version for the version.
  * 3. To validate the v1 request signature:
@@ -238,43 +234,46 @@ export function validateSaaSquatchWebhook(
  *      a) Create a string concatinating the Client secret + http method + URI + request body
  *      b) Create a SHA-256 hash of the string
  *      c) Compare hash to X-HubSpot-Signature
- * 
+ *
  * REF: https://developers.hubspot.com/docs/api/webhooks/validating-requests
  *
  * @param webhookBody The raw text of the webhook body.
  * @param signatureVersion The value of the X-HubSpot-Signature-Version header.
  * @param signature The value of the X-HubSpot-Signature header
  */
- export function validateHubSpotWebhook(signatureVersion: string, signature: string, webhookBody?: string) {
-    if(!HUBSPOT_CLIENT_SECRET){
-        console.error("Missing HUBSPOT_CLIENT_SECRET in env variables. The HUBSPOT_CLIENT_SECRET is required to \
-        validate HubSpot Webhooks.");
+export function validateHubSpotWebhook(signatureVersion: string, signature: string, webhookBody?: string): boolean {
+    if (!HUBSPOT_CLIENT_SECRET) {
+        console.error(
+            'Missing HUBSPOT_CLIENT_SECRET in env variables. The HUBSPOT_CLIENT_SECRET is required to \
+        validate HubSpot Webhooks.',
+        );
         return false;
     }
-    var sourceString: string;
+    let sourceString: string;
     // If X-HubSpot-Signature header is version 1
-    if(signatureVersion == 'v1'){
+    if (signatureVersion == 'v1') {
         sourceString = HUBSPOT_CLIENT_SECRET;
     }
     // If X-HubSpot-Signature header is version 2
-    else if(signatureVersion == 'v2'){
-        if(!HUBSPOT_WEBHOOK_URI){
-            console.error("HUBSPOT_WEBHOOK_URI missing in env variables. The HUBSPOT_WEBHOOK_URI is required to \
-            validate Version 2 X-HubSpot-Signatures.");
+    else if (signatureVersion == 'v2') {
+        if (!HUBSPOT_WEBHOOK_URI) {
+            console.error(
+                'HUBSPOT_WEBHOOK_URI missing in env variables. The HUBSPOT_WEBHOOK_URI is required to \
+            validate Version 2 X-HubSpot-Signatures.',
+            );
             return false;
         }
         const uri = encodeURI(HUBSPOT_WEBHOOK_URI);
-        sourceString = HUBSPOT_CLIENT_SECRET + "POST" + uri;
+        sourceString = HUBSPOT_CLIENT_SECRET + 'POST' + uri;
     }
     // If X-HubSpot-Signature header is missing webhook is invalid.
-    else{
-        console.error("Invalid or missing X-HubSpot-Signature-Version header.");
+    else {
+        console.error('Invalid or missing X-HubSpot-Signature-Version header.');
         return false;
     }
-    if(webhookBody) sourceString += webhookBody;
+    if (webhookBody) sourceString += webhookBody;
     const hash = crypto.createHash('sha256').update(sourceString).digest('hex');
     return hash == signature;
 }
-
 
 export default router;

--- a/src/test/generate-share-links-for-hubspot-contacts.steps.ts
+++ b/src/test/generate-share-links-for-hubspot-contacts.steps.ts
@@ -1,71 +1,79 @@
 import { loadFeature, defineFeature } from 'jest-cucumber';
-import { HubspotPayload, SubscriptionType } from '../Types/types';
+import { SubscriptionType } from '../Types/types';
 import { validateHubSpotWebhook } from '../routes/webhooks';
 import hubspotSchema from '../Types/hubspot-payload-schema.json';
-import Ajv from "ajv";
+import Ajv from 'ajv';
 
-const ShareLinkForHubspotContacts = loadFeature('features/Hubspot-to-SaaSquatch/Generate Share Links For Hubspot Contacts.feature');
+const ShareLinkForHubspotContacts = loadFeature(
+    'features/Hubspot-to-SaaSquatch/Generate Share Links For Hubspot Contacts.feature',
+);
 
-
-defineFeature(ShareLinkForHubspotContacts, test => {
+defineFeature(ShareLinkForHubspotContacts, (test) => {
     const validWebhookRequestBody: any = [
         {
-          "objectId": 1246965,
-          "propertyName": "lifecyclestage",
-          "propertyValue": "subscriber",
-          "changeSource": "ACADEMY",
-          "eventId": 3816279340,
-          "subscriptionId": 25,
-          "portalId": 33,
-          "appId": 1160452,
-          "occurredAt": 1462216307945,
-          "subscriptionType":"contact.propertyChange",
-          "attemptNumber": 0
+            objectId: 1246965,
+            propertyName: 'lifecyclestage',
+            propertyValue: 'subscriber',
+            changeSource: 'ACADEMY',
+            eventId: 3816279340,
+            subscriptionId: 25,
+            portalId: 33,
+            appId: 1160452,
+            occurredAt: 1462216307945,
+            subscriptionType: 'contact.propertyChange',
+            attemptNumber: 0,
         },
         {
-          "objectId": 1246978,
-          "changeSource": "IMPORT",
-          "eventId": 3816279480,
-          "subscriptionId": 22,
-          "portalId": 33,
-          "appId": 1160452,
-          "occurredAt": 1462216307945,
-          "subscriptionType": "contact.creation",
-          "attemptNumber": 0
-        }
+            objectId: 1246978,
+            changeSource: 'IMPORT',
+            eventId: 3816279480,
+            subscriptionId: 22,
+            portalId: 33,
+            appId: 1160452,
+            occurredAt: 1462216307945,
+            subscriptionType: 'contact.creation',
+            attemptNumber: 0,
+        },
     ];
 
     const testFakeClientSecret = process.env.HUBSPOT_CLIENT_SECRET;
     const webhookSigVersion = 'v1';
-    const crypto = require("crypto");
-    const webhookSig = crypto.createHash('sha256').update(testFakeClientSecret + validWebhookRequestBody).digest('hex');
+    const crypto = require('crypto');
+    const webhookSig = crypto
+        .createHash('sha256')
+        .update(testFakeClientSecret + validWebhookRequestBody)
+        .digest('hex');
 
     const invalidWebhookRequestBody: any = [
         {
-          "objectId": 1246978,
-          "changeSource": "IMPORT",
-          "eventId": 3816279480,
-          "subscriptionId": 22,
-          "portalId": 33,
-          "appId": 1160452,
-          "occurredAt": "contact.creation",
-          "subscriptionType": 0,
-          "attemptNumber": null
-        }
+            objectId: 1246978,
+            changeSource: 'IMPORT',
+            eventId: 3816279480,
+            subscriptionId: 22,
+            portalId: 33,
+            appId: 1160452,
+            occurredAt: 'contact.creation',
+            subscriptionType: 0,
+            attemptNumber: null,
+        },
     ];
 
     const invalidWebhookSig = crypto.createHash('sha256').update(JSON.stringify(validWebhookRequestBody)).digest('hex');
 
     // JSON schema validator
     const ajv: any = new Ajv();
-    const hubSchema: Object = hubspotSchema;
-    ajv.addSchema(hubSchema, "hubspot");
+    const hubSchema: any = hubspotSchema;
+    ajv.addSchema(hubSchema, 'hubspot');
 
-    const validateHubspotSchema = ajv.getSchema("hubspot");
+    const validateHubspotSchema = ajv.getSchema('hubspot');
 
-
-
-    test('New HubSpot Contacts that do not yet exist in SaaSquatch get share links', ({given, when, but, then, and}) => {
+    test('New HubSpot Contacts that do not yet exist in SaaSquatch get share links', ({
+        given,
+        when,
+        but,
+        then,
+        and,
+    }) => {
         given('The integration is active', () => {
             // This is assumed for now, as system config in db is not yet set up
         });
@@ -77,11 +85,10 @@ defineFeature(ShareLinkForHubspotContacts, test => {
 
             // confirm invalid webhook from not HubSpot (fake webhook)
             expect(validateHubSpotWebhook(webhookSigVersion, invalidWebhookSig, validWebhookRequestBody)).toBe(false);
-            // confirm JSON Schema validation fails on malformed webhook JSON 
-            expect(validateHubspotSchema(invalidWebhookRequestBody)).toBe(false);            
-
+            // confirm JSON Schema validation fails on malformed webhook JSON
+            expect(validateHubspotSchema(invalidWebhookRequestBody)).toBe(false);
         });
-        but('they don\'t exist in SaaSquatch', () => {
+        but("they don't exist in SaaSquatch", () => {
             //api call to get saasquatch users
             //match on email
         });
@@ -93,14 +100,12 @@ defineFeature(ShareLinkForHubspotContacts, test => {
         });
     });
 
-   
-    test('New HubSpot Contacts that already exist in SaaSquatch get share links', ({given, when, and, then}) => {
+    test('New HubSpot Contacts that already exist in SaaSquatch get share links', ({ given, when, and, then }) => {
         given('The integration is active', () => {
             // This is assumed for now, as system config in db is not yet set up
         });
         when('A Contact is created in Hubspot', () => {
             // validate webhook from HubSpot
-            
         });
         and('they exist in SaaSquatch', () => {
             //api call to get saasquatch users
@@ -109,10 +114,5 @@ defineFeature(ShareLinkForHubspotContacts, test => {
         then('their share link shows up back in Hubspot', () => {
             //api call at add share link to hubspot user
         });
-        
     });
-
-
-
-
 });

--- a/src/test/index.steps.ts
+++ b/src/test/index.steps.ts
@@ -3,7 +3,7 @@ import { loadFeature, defineFeature } from 'jest-cucumber';
 const MatchUsersAndContacts = loadFeature('features/MatchUsersContacts.feature');
 
 //This is just a toy example for demonstration.
-defineFeature(MatchUsersAndContacts, test => {
+defineFeature(MatchUsersAndContacts, (test) => {
     let emailSaasquatch: string, emailHubspot: string;
 
     function update(a: string, b: string) {
@@ -12,9 +12,9 @@ defineFeature(MatchUsersAndContacts, test => {
         } else {
             return false;
         }
-    };
+    }
 
-    test('Matching email address', ({given, when, then, and}) => {
+    test('Matching email address', ({ given, when, then, and }) => {
         given('A user with the email address adamh@gmail.com', () => {
             emailSaasquatch = 'adamh@gmail.com';
         });
@@ -23,12 +23,12 @@ defineFeature(MatchUsersAndContacts, test => {
             emailHubspot = 'adamh@gmail.com';
         });
 
-        when('User\'s are synced from SaaSquatch to Contacts in Hubspot', () => {
+        when("User's are synced from SaaSquatch to Contacts in Hubspot", () => {
             //sync()
         });
 
         then('adamh@gmail.com is updated, not created in Hubspot', () => {
-            expect(update(emailSaasquatch,emailHubspot)).toBe(true);
+            expect(update(emailSaasquatch, emailHubspot)).toBe(true);
         });
     });
 });

--- a/src/test/oauth/hubspot-oauth.steps.ts
+++ b/src/test/oauth/hubspot-oauth.steps.ts
@@ -2,53 +2,59 @@
  * Integration tests for testing the interaction between the integration and Hubspot's refresh token API.
  */
 
-import { loadFeature, defineFeature, DefineStepFunction } from 'jest-cucumber';
+import { loadFeature, defineFeature } from 'jest-cucumber';
 import { getHubspotAccessToken } from '../../routes/oath';
 require('dotenv').config();
 
 const HubspotOauth = loadFeature('features/Oauth/High-Level/Hubspot-Oauth.feature', {
-	tagFilter: 'not @manual'
+    tagFilter: 'not @manual',
 });
 
-defineFeature(HubspotOauth, test => {
-	test('The integration is able to obtain a new refresh token from Hubspot', ({ given, when, then, and }) => {
-		const connectedRefreshToken = process.env.HUBSPOT_REFRESH_TOKEN_CONNECTED; // TODO: remove and connect to firebase if we want to set test accounts
-		let data: any;
+defineFeature(HubspotOauth, (test) => {
+    test('The integration is able to obtain a new refresh token from Hubspot', ({ given, when, then, and }) => {
+        const connectedRefreshToken = process.env.HUBSPOT_REFRESH_TOKEN_CONNECTED; // TODO: remove and connect to firebase if we want to set test accounts
+        let data: any;
 
-		given('The user has completed the integration\'s Hubspot oauth flow', () => {});
+        given("The user has completed the integration's Hubspot oauth flow", () => {
+            // TODO: can check firebase db access tokens to verify this
+        });
 
         when('The integration needs a new refresh token from Hubspot', async () => {
-			try {
-				data = await getHubspotAccessToken(connectedRefreshToken);
-			} catch (e) {
-				expect(e).toBeUndefined();
-			}
+            try {
+                data = await getHubspotAccessToken(connectedRefreshToken);
+            } catch (e) {
+                expect(e).toBeUndefined();
+            }
         });
 
         then('A new refresh token should be returned from Hubspot', () => {
-			expect(data["refresh_token"]).toBe(connectedRefreshToken);
-			expect(data["access_token"]).toBeDefined();
+            expect(data['refresh_token']).toBe(connectedRefreshToken);
+            expect(data['access_token']).toBeDefined();
         });
-	});
+    });
 
-	test('The integration is not able to obtain a new refresh token from Hubspot', ({ given, when, then, and }) => {
-		const disconnectedRefreshToken = process.env.HUBSPOT_REFRESH_TOKEN_DISCONNECTED;
-		let data: Map<string, any>;
-       
-		given('The user has completed the integration\'s Hubspot oauth flow before', () => {});
+    test('The integration is not able to obtain a new refresh token from Hubspot', ({ given, when, then, and }) => {
+        const disconnectedRefreshToken = process.env.HUBSPOT_REFRESH_TOKEN_DISCONNECTED;
+        let data: Map<string, any>;
 
-        and('The integration app is disconnected on the users Hubspot account', () => {});
+        given("The user has completed the integration's Hubspot oauth flow before", () => {
+            // TODO: can check firebase db access tokens to verify this
+        });
+
+        and('The integration app is disconnected on the users Hubspot account', () => {
+            // TODO: find a way to set this, API call to HubSpot?
+        });
 
         when('The integration needs a new refresh token from Hubspot', async () => {
-			try {
-				data = await getHubspotAccessToken(disconnectedRefreshToken);
-			} catch (e) {
-				expect(e).toBeDefined();
-			}
+            try {
+                data = await getHubspotAccessToken(disconnectedRefreshToken);
+            } catch (e) {
+                expect(e).toBeDefined();
+            }
         });
 
         then('A new refresh token is not returned from Hubspot', () => {
-			expect(data).toBeUndefined();
+            expect(data).toBeUndefined();
         });
-	});
+    });
 });

--- a/src/test/oauth/saasquatch-oauth.steps.ts
+++ b/src/test/oauth/saasquatch-oauth.steps.ts
@@ -2,42 +2,51 @@
  * Integration tests for testing the interaction between the integration and Saasquatch's API JWT.
  */
 
-import { loadFeature, defineFeature, DefineStepFunction } from 'jest-cucumber';
+import { loadFeature, defineFeature } from 'jest-cucumber';
 import { getSaasquatchToken } from '../../routes/oath';
 
 const SaasquatchOauthDetails = loadFeature('features/Oauth/Low-Level/Saasquatch-Oauth-Details.feature', {
-	tagFilter: 'not @manual'
+    tagFilter: 'not @manual',
 });
 
-defineFeature(SaasquatchOauthDetails, test => {
+defineFeature(SaasquatchOauthDetails, (test) => {
+    test('Integration requests auth0 JWT from Saasquatch correctly', ({ given, when, then, and }) => {
+        let data: any;
 
-	test('Integration requests auth0 JWT from Saasquatch correctly', ({given, when, then, and}) => {
-		let data: any;
-
-		given('The integration is enabled on the tennant\'s integrations page', () => {
-			// Done manually
+        given("The integration is enabled on the tennant's integrations page", () => {
+            // Done manually
         });
 
-        and('The integration needs a new JWT from Saasquatch', () => {});
+        and('The integration needs a new JWT from Saasquatch', () => {
+            // The previous JWT is expired, etc.
+        });
 
-        when('The integration sends a post request to Saasquatch\'s auth0 sever', async () => {
-			try {
-				data = await getSaasquatchToken();
-			} catch (e) {
-				expect(e).toBeUndefined();
-			}
-		});
+        when("The integration sends a post request to Saasquatch's auth0 sever", async () => {
+            try {
+                data = await getSaasquatchToken();
+            } catch (e) {
+                expect(e).toBeUndefined();
+            }
+        });
 
-        and('Includes a \'grant_type\' parameter that has a value of \'client_credentials\'', () => {});
+        and("Includes a 'grant_type' parameter that has a value of 'client_credentials'", () => {
+            // Done in getSaasquatchToken()
+        });
 
-        and('Includes a \'client_id\' parameter that has a value of the integration\'s client ID', () => {});
+        and("Includes a 'client_id' parameter that has a value of the integration's client ID", () => {
+            // Done in getSaasquatchToken()
+        });
 
-        and('Includes a \'client_secret\' parameter that has a value of the integration\'s client secret', () => {});
+        and("Includes a 'client_secret' parameter that has a value of the integration's client secret", () => {
+            // Done in getSaasquatchToken()
+        });
 
-        and('Includes a \'audience\' parameter that has a value of \'https://staging.referralsaasquatch.com\'', () => {});
+        and("Includes a 'audience' parameter that has a value of 'https://staging.referralsaasquatch.com'", () => {
+            // Done in getSaasquatchToken()
+        });
 
         then('A new JWT should be included in the response', () => {
-			expect(data["access_token"]).toBeDefined();
-		});
-	});
+            expect(data['access_token']).toBeDefined();
+        });
+    });
 });


### PR DESCRIPTION
This PR adds `eslint` to our project and `prettier`. It is now required for the linter to pass before you will be able to make a commit. Prettier will remove extra lines breaks, etc. and is more towards formatting. Eslint will warn about console.logs etc. and will automatically fix missing semicolons.

To run eslint: `yarn run lint`
To run prettier `yarn run prettify`

These will automatically be run when you try to make a commit. If they fail, your commit will fail and you will need to fix the linting errors before committing.

This change touched a lot of files because I had to fix a bunch of linting errors in order to commit this. There are still a lot of warnings that show up if you run `yarn run lint`, and it would be a good idea to run this before committing to make sure we are deliberate about what warnings we are adding. Warnings that show up but do not fail the commit include having a type of `any` and `console.log`s. 

The actual files relevant to making this addition are:
- package.json
- .eslintrc.js
- .lintstagedrc.js
- .husky/
- .eslintignore