### PR TITLE
Add Enable Cookies Error

### DIFF
--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -80,6 +80,7 @@ export function OAuthFunction(){
           var timer = setInterval(function() { 
             if(popup && popup.closed) {
               if (!navigator.cookieEnabled) {
+                document.cookie="frontendToken=''; SameSite=None; Secure";
                 setCookieError(true)
               } else {
                 // Check Server for Hubspot Authorization

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -70,6 +70,7 @@ export function OAuthFunction(){
     // Check Server for Hubspot Authorization
     await axios.get(HUBSPOT_AUTHORIZATION)
     .then(response => {
+      console.log(document.cookie)
       if (response.data === "Unauthorized"){
         // Get Hubspot OAuth URL from server
         axios.get(HUBSPOT_OAUTH_URL)
@@ -81,6 +82,7 @@ export function OAuthFunction(){
             if(popup && popup.closed) {
               if (!navigator.cookieEnabled) {
                 document.cookie="frontendToken=''; SameSite=None; Secure";
+                console.log(document.cookie)
                 setCookieError(true)
               } else {
                 // Check Server for Hubspot Authorization

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -80,7 +80,8 @@ export function OAuthFunction(){
           var timer = setInterval(function() { 
             if(popup && popup.closed) {
               if (!navigator.cookieEnabled) {
-                document.cookie="frontendToken=''; SameSite=None; Secure";
+                const token = undefined;
+                document.cookie=`frontendToken=${token}; SameSite=None; Secure`;
                 setCookieError(true)
               } else {
                 // Check Server for Hubspot Authorization

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -70,7 +70,6 @@ export function OAuthFunction(){
     // Check Server for Hubspot Authorization
     await axios.get(HUBSPOT_AUTHORIZATION)
     .then(response => {
-      console.log(document.cookie)
       if (response.data === "Unauthorized"){
         // Get Hubspot OAuth URL from server
         axios.get(HUBSPOT_OAUTH_URL)
@@ -82,7 +81,6 @@ export function OAuthFunction(){
             if(popup && popup.closed) {
               if (!navigator.cookieEnabled) {
                 document.cookie="frontendToken=''; SameSite=None; Secure";
-                console.log(document.cookie)
                 setCookieError(true)
               } else {
                 // Check Server for Hubspot Authorization

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,150 +1,167 @@
-import React, {useState} from "react";
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import HubspotLogo from '../assets/HubspotLogo.png';
 import axios from 'axios';
 import history from '../types/history';
 
 const Wrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 `;
 const Logo = styled.img`
-  height: 60px;
+    height: 60px;
 `;
 const TitleText = styled.h1`
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  color: #33475B;
-  text-align: left;
-  margin: 0px;
-  font-size: 48px;
-  font-weight: bold;
-  display: flex;
+    font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    color: #33475b;
+    text-align: left;
+    margin: 0px;
+    font-size: 48px;
+    font-weight: bold;
+    display: flex;
 `;
 const InfoText = styled.p`
-  color: #000000;
-  font-size: 20px;
-  display: flex;
-  margin-right: 5px;
+    color: #000000;
+    font-size: 20px;
+    display: flex;
+    margin-right: 5px;
 `;
 const LoginButton = styled.button`
-  &:hover {
-    background-color: #FF8661
-  }
-  font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-weight: 400;
-  border: 0;
-  border-radius: 1em;
-  cursor: pointer;
-  color: white;
-  background-color: #FF7A59;
-  display: inherit;
-  font-size: 36px;
-  width: 180px;
-  height: 80px;
+    &:hover {
+        background-color: #ff8661;
+    }
+    font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    border: 0;
+    border-radius: 1em;
+    cursor: pointer;
+    color: white;
+    background-color: #ff7a59;
+    display: inherit;
+    font-size: 36px;
+    width: 180px;
+    height: 80px;
 `;
 const ErrorText = styled.p`
-    color: #F92929;
+    color: #f92929;
     font-size: 20px;
     display: flex;
 `;
 
-const HUBSPOT_AUTHORIZATION= '/hubspot_authorization'
-const HUBSPOT_OAUTH_URL = '/hubspot_url'
+const HUBSPOT_AUTHORIZATION = '/hubspot_authorization';
+const HUBSPOT_OAUTH_URL = '/hubspot_url';
 
 interface states {
-  showError: boolean;
-  cookieError: boolean;
-  OAuth: ()=>void;
+    showError: boolean;
+    cookieError: boolean;
+    OAuth: () => void;
 }
 
 export function Login() {
-  return <View {...OAuthFunction()} />
+    return <View {...OAuthFunction()} />;
 }
 
-export function OAuthFunction(){
-  const [showError, setError] = useState(false);
-  const [cookieError, setCookieError] = useState(false);
-  
-  const OAuth = async () => {
-    // Check Server for Hubspot Authorization
-    await axios.get(HUBSPOT_AUTHORIZATION)
-    .then(response => {
-      if (response.data === "Unauthorized"){
-        // Get Hubspot OAuth URL from server
-        axios.get(HUBSPOT_OAUTH_URL)
-        .then( response => {
-          // Open popup for Hubspot OAuth URL
-          const popup = window.open(response.data, "OAuth Popup",`toolbar=no, location=no, statusbar=no, menubar=no, scrollbars=1, resizable=0, width=${500}, height=${800}, top=150, left=650`);
-          // Check for when popup closes
-          var timer = setInterval(function() { 
-            if(popup && popup.closed) {
-              if (!navigator.cookieEnabled) {
-                const token = undefined;
-                document.cookie=`frontendToken=${token}; SameSite=None; Secure`;
-                setCookieError(true)
-              } else {
-                // Check Server for Hubspot Authorization
-                axios.get(HUBSPOT_AUTHORIZATION)
-                .then(response => {
-                  // Send user to configuration page if authorized
-                  if (response.data === "Authorized"){
-                    clearInterval(timer);
+export function OAuthFunction() {
+    const [showError, setError] = useState(false);
+    const [cookieError, setCookieError] = useState(false);
+
+    const OAuth = async () => {
+        // Check Server for Hubspot Authorization
+        await axios
+            .get(HUBSPOT_AUTHORIZATION)
+            .then((response) => {
+                if (response.data === 'Unauthorized') {
+                    // Get Hubspot OAuth URL from server
+                    axios
+                        .get(HUBSPOT_OAUTH_URL)
+                        .then((response) => {
+                            // Open popup for Hubspot OAuth URL
+                            const popup = window.open(
+                                response.data,
+                                'OAuth Popup',
+                                `toolbar=no, location=no, statusbar=no, menubar=no, scrollbars=1, resizable=0, width=${500}, height=${800}, top=150, left=650`,
+                            );
+                            // Check for when popup closes
+                            var timer = setInterval(function () {
+                                if (popup && popup.closed) {
+                                    if (!navigator.cookieEnabled) {
+                                        document.cookie = "frontendToken=''; SameSite=None; Secure";
+                                        setCookieError(true);
+                                    } else {
+                                        // Check Server for Hubspot Authorization
+                                        axios
+                                            .get(HUBSPOT_AUTHORIZATION)
+                                            .then((response) => {
+                                                // Send user to configuration page if authorized
+                                                if (response.data === 'Authorized') {
+                                                    clearInterval(timer);
+                                                    history.push('/configuration');
+                                                }
+                                                // Show error message when popup window is closed without Authorization
+                                                if (response.data === 'Unauthorized') {
+                                                    clearInterval(timer);
+                                                    setTimeout(function () {
+                                                        setError(true);
+                                                    }, 600);
+                                                }
+                                            })
+                                            .catch(function (err) {
+                                                console.error(
+                                                    err +
+                                                        'Error getting Hubspot Authorization from: ' +
+                                                        HUBSPOT_AUTHORIZATION,
+                                                );
+                                            });
+                                    }
+                                }
+                            }, 200);
+                        })
+                        .catch(function (err) {
+                            console.error(err + 'Error getting Hubspot URL from: ' + HUBSPOT_OAUTH_URL);
+                        });
+                } else {
                     history.push('/configuration');
-                  }
-                  // Show error message when popup window is closed without Authorization
-                  if (response.data === "Unauthorized") {
-                    clearInterval(timer);
-                    setTimeout(function(){ 
-                    setError(true)
-                    }, 600);
-                  }
-                })
-                .catch(function(err) {
-                  console.error(err + "Error getting Hubspot Authorization from: " + HUBSPOT_AUTHORIZATION);
-                });
-              }
-            }
-          }, 200);
-        })
-        .catch(function(err) {
-          console.error(err + "Error getting Hubspot URL from: " + HUBSPOT_OAUTH_URL);
-        });
-      } else {
-        history.push('/configuration');
-      }
-    })
-    .catch(function(err) {
-      console.error(err + "Error getting Hubspot Authorization from: " + HUBSPOT_AUTHORIZATION);
-    });
-  }
-  return {showError, cookieError, OAuth} as states
+                }
+            })
+            .catch(function (err) {
+                console.error(err + 'Error getting Hubspot Authorization from: ' + HUBSPOT_AUTHORIZATION);
+            });
+    };
+    return { showError, cookieError, OAuth } as states;
 }
 
-export function View( states: states ){
-  return (
-    <Wrapper className= "wrapper">
-      <div>
-        <TitleText className= "title-text"> Log in to <Logo src={HubspotLogo} /></TitleText>
-        <InfoText className= "info-text">Your contacts will be synced using the HubSpot data from this user’s permissions.</InfoText>
-        <LoginButton 
-          onClick={states.OAuth}
-          type= "button"
-          className={"login-button"}
-        >
-          {"Log in"}
-        </LoginButton>
-        <div>
-          { states.showError ? <ErrorText>
-            Failed to authenticate: The pop-up window was closed before authentication.
-          </ErrorText> : <React.Fragment />
-          }
-          { states.cookieError ? <ErrorText>
-            Failed to authenticate: Please enable third-party cookies and try logging in again.
-          </ErrorText> : <React.Fragment />
-          }
-        </div>
-      </div>
-    </Wrapper>
-   );
- }
+export function View(states: states) {
+    return (
+        <Wrapper className="wrapper">
+            <div>
+                <TitleText className="title-text">
+                    {' '}
+                    Log in to <Logo src={HubspotLogo} />
+                </TitleText>
+                <InfoText className="info-text">
+                    Your contacts will be synced using the HubSpot data from this user’s permissions.
+                </InfoText>
+                <LoginButton onClick={states.OAuth} type="button" className={'login-button'}>
+                    {'Log in'}
+                </LoginButton>
+                <div>
+                    {states.showError ? (
+                        <ErrorText>
+                            Failed to authenticate: The pop-up window was closed before authentication.
+                        </ErrorText>
+                    ) : (
+                        <React.Fragment />
+                    )}
+                    {states.cookieError ? (
+                        <ErrorText>
+                            Failed to authenticate: Please enable third-party cookies and try logging in again.
+                        </ErrorText>
+                    ) : (
+                        <React.Fragment />
+                    )}
+                </div>
+            </div>
+        </Wrapper>
+    );
+}

--- a/frontend/src/stories/Login.stories.tsx
+++ b/frontend/src/stories/Login.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import { View } from '../components/Login';
 
-const props = {showError: false, OAuth: ()=>console.log("Sign in")};
+const props = {showError: false, cookieError: false, OAuth: ()=>console.log("Sign in")};
 const OpenPopup = () => {
   const h = 800;
   const w = 500;
@@ -18,6 +18,7 @@ export default {
 
 export const Default = ()=> <View {...props} />
 export const Error = ()=> <View {...props} showError={true} />
+export const CookieError = ()=> <View {...props} cookieError={true} />
 export const ClickForPopup = ()=> <View {...props} OAuth={OpenPopup} />
 
 

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -17,7 +17,7 @@ const API_CONFIGURATION_URL = '/api/configuration';
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken) {
+	if(req.cookies.frontendToken !== '') {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if (decoded != undefined) {
@@ -32,7 +32,7 @@ router.get(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.post(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken) {
+	if(req.cookies.frontendToken !== '') {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {
@@ -52,7 +52,7 @@ router.post(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.put(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken) {
+	if(req.cookies.frontendToken !== '') {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -17,7 +17,7 @@ const API_CONFIGURATION_URL = '/api/configuration';
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken != '') {
+	if(req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if (decoded != undefined) {
@@ -32,7 +32,7 @@ router.get(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.post(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken != '') {
+	if(req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {
@@ -52,7 +52,7 @@ router.post(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.put(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken != '') {
+	if(req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -6,7 +6,7 @@ import { Configuration } from '../Types/types';
 import { ConfigurationController } from '../integration/ConfigurationController';
 import { authenticateToken } from './oath';
 
-import { MOCK_SESSION_HUBSPOT_ID } from '../mock'
+import { MOCK_SESSION_HUBSPOT_ID } from '../mock';
 
 const router = Router();
 const ajv = new Ajv();
@@ -16,59 +16,59 @@ const validate = ajv.compile(ConfigurationPayloadSchema);
 const API_CONFIGURATION_URL = '/api/configuration';
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
-	let decoded = undefined
-	if(req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
-		decoded = authenticateToken(req.cookies.frontendToken as string)
-	}
-	if (decoded != undefined) {
-		const configuration = await ConfigurationController.getConfiguration(req.query.SaaSquatchTenantAlias as string)
-		res.json(configuration)
-		res.end();
-	} else {
-		console.error(`GET ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`)
-		res.sendStatus(400);
-		res.end();
-	}
-})
+    let decoded = undefined;
+    if (req.cookies.frontendToken) {
+        decoded = authenticateToken(req.cookies.frontendToken as string);
+    }
+    if (decoded != undefined) {
+        const configuration = await ConfigurationController.getConfiguration(req.query.SaaSquatchTenantAlias as string);
+        res.json(configuration);
+        res.end();
+    } else {
+        console.error(`GET ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`);
+        res.sendStatus(400);
+        res.end();
+    }
+});
 router.post(API_CONFIGURATION_URL, async (req, res) => {
-	let decoded = undefined
-	if(req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
-		decoded = authenticateToken(req.cookies.frontendToken as string)
-	}
-	if(validate(req.body) && decoded != undefined) {
-		const configuration: Configuration = req.body as Configuration
-		ConfigurationController.setConfiguration(MOCK_SESSION_HUBSPOT_ID, configuration)
-		res.sendStatus(200)
-		res.end()
-	} else if (!validate(req.body)) {
-		console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate response body`)
-		res.sendStatus(400);
-		res.end();
-	} else if (decoded === undefined) {
-		console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`)
-		res.sendStatus(400);
-		res.end();
-	}
-})
+    let decoded = undefined;
+    if (req.cookies.frontendToken) {
+        decoded = authenticateToken(req.cookies.frontendToken as string);
+    }
+    if (validate(req.body) && decoded != undefined) {
+        const configuration: Configuration = req.body as Configuration;
+        ConfigurationController.setConfiguration(MOCK_SESSION_HUBSPOT_ID, configuration);
+        res.sendStatus(200);
+        res.end();
+    } else if (!validate(req.body)) {
+        console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate response body`);
+        res.sendStatus(400);
+        res.end();
+    } else if (decoded === undefined) {
+        console.error(`POST ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`);
+        res.sendStatus(400);
+        res.end();
+    }
+});
 router.put(API_CONFIGURATION_URL, async (req, res) => {
-	let decoded = undefined
-	if(req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
-		decoded = authenticateToken(req.cookies.frontendToken as string)
-	}
-	if(validate(req.body) && decoded != undefined) {
-		const configuration: Configuration = req.body as Configuration
-		ConfigurationController.updateConfiguration(configuration)
-		res.sendStatus(200)
-		res.end()
-	} else if (!validate(req.body)) {
-		console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate response body`)
-		res.sendStatus(400);
-		res.end();
-	} else if (decoded === undefined){
-		console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`)
-		res.sendStatus(400);
-		res.end();
-	}
-})
+    let decoded = undefined;
+    if (req.cookies.frontendToken) {
+        decoded = authenticateToken(req.cookies.frontendToken as string);
+    }
+    if (validate(req.body) && decoded != undefined) {
+        const configuration: Configuration = req.body as Configuration;
+        ConfigurationController.updateConfiguration(configuration);
+        res.sendStatus(200);
+        res.end();
+    } else if (!validate(req.body)) {
+        console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate response body`);
+        res.sendStatus(400);
+        res.end();
+    } else if (decoded === undefined) {
+        console.error(`PUT ${API_CONFIGURATION_URL} -> Failed to validate OAuth token`);
+        res.sendStatus(400);
+        res.end();
+    }
+});
 
 export { router as configurationRoutes };

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -17,7 +17,7 @@ const API_CONFIGURATION_URL = '/api/configuration';
 
 router.get(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken !== '') {
+	if(req.cookies.frontendToken != '') {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if (decoded != undefined) {
@@ -32,7 +32,7 @@ router.get(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.post(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken !== '') {
+	if(req.cookies.frontendToken != '') {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {
@@ -52,7 +52,7 @@ router.post(API_CONFIGURATION_URL, async (req, res) => {
 })
 router.put(API_CONFIGURATION_URL, async (req, res) => {
 	let decoded = undefined
-	if(req.cookies.frontendToken !== '') {
+	if(req.cookies.frontendToken != '') {
 		decoded = authenticateToken(req.cookies.frontendToken as string)
 	}
 	if(validate(req.body) && decoded != undefined) {

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -115,7 +115,7 @@ export const getSaasquatchToken = async (): Promise<any> => {
 // 1. Check whether user has previously authenticated with Hubspot and received a token
 router.get('/hubspot_authorization', async (req, res) => {
     let decoded = undefined;
-    if (req.cookies.frontendToken != '') {
+    if (req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
         decoded = authenticateToken(req.cookies.frontendToken as string);
     }
     if (decoded != undefined) {

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -115,7 +115,7 @@ export const getSaasquatchToken = async (): Promise<any> => {
 // 1. Check whether user has previously authenticated with Hubspot and received a token
 router.get('/hubspot_authorization', async (req, res) => {
     let decoded = undefined;
-    if (req.cookies.frontendToken) {
+    if (req.cookies.frontendToken !== '') {
         decoded = authenticateToken(req.cookies.frontendToken as string);
     }
     if (decoded != undefined) {

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -115,7 +115,7 @@ export const getSaasquatchToken = async (): Promise<any> => {
 // 1. Check whether user has previously authenticated with Hubspot and received a token
 router.get('/hubspot_authorization', async (req, res) => {
     let decoded = undefined;
-    if (req.cookies.frontendToken && req.cookies.frontendToken != undefined) {
+    if (req.cookies.frontendToken) {
         decoded = authenticateToken(req.cookies.frontendToken as string);
     }
     if (decoded != undefined) {

--- a/src/routes/oath.ts
+++ b/src/routes/oath.ts
@@ -115,7 +115,7 @@ export const getSaasquatchToken = async (): Promise<any> => {
 // 1. Check whether user has previously authenticated with Hubspot and received a token
 router.get('/hubspot_authorization', async (req, res) => {
     let decoded = undefined;
-    if (req.cookies.frontendToken !== '') {
+    if (req.cookies.frontendToken != '') {
         decoded = authenticateToken(req.cookies.frontendToken as string);
     }
     if (decoded != undefined) {


### PR DESCRIPTION
Currently cookies in the SaaSquatch iFrame need third-party cookies enabled. This PR adds an error message for the user if they don't have cookies enabled. The Hubspot Quickstart guide was also removed.

https://trello.com/c/Q0mtTolQ/134-warning-to-enable-third-party-cookies