### PR TITLE
Fix poll database function and add login check to last page

### DIFF
--- a/frontend/src/components/OrderConfirmation.tsx
+++ b/frontend/src/components/OrderConfirmation.tsx
@@ -154,6 +154,7 @@ export function Controller(state: Config) {
                         });
                 })
                 .catch(function (err) {
+                    history.push('/login');
                     console.error(err + 'Error getting Hubspot Authorization from: ' + HUBSPOT_AUTHORIZATION);
                 });
         };

--- a/src/database.ts
+++ b/src/database.ts
@@ -198,10 +198,8 @@ export async function PollDatabase(tenantAlias: string): Promise<Configuration> 
                 'PushContactsAsParticipants',
                 'PullContactsIntoParticipants',
                 'DeleteParticipantWhenContactDeleted',
-                'hubspotID',
-                'accessToken',
-                'refreshToken',
             ].reduce(snapshotReducerFactory('hubspot'), {}),
+            ...['hubspotID', 'accessToken', 'refreshToken'].reduce(snapshotReducerFactory('userinfo'), {}),
         } as Configuration;
     } else {
         return {


### PR DESCRIPTION
This is a fix for the poll database function, it was no longer properly getting the hubspotID, access token, or refresh token from the database and caused the integration error message to appear whenever an existing user tried to log in. I also added a login check to the new order confirmation page so it can only be accessed by a logged in user.